### PR TITLE
chore: Upgrade codecov-action version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,4 +25,4 @@ jobs:
       - run: npm run build
       - run: npm run test
       - name: Codecov
-        uses: codecov/codecov-action@v1.5.2
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
*Description of changes:*
Upgrade codecov-action version to the latest major version as version 1.x has been deprecated.

https://github.com/codecov/codecov-action

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
