### PR TITLE
chore: Remove unused `loading` property

### DIFF
--- a/src/__tests__/stubs.tsx
+++ b/src/__tests__/stubs.tsx
@@ -43,7 +43,6 @@ const Table = React.forwardRef<CollectionRef, TableProps>(
   (
     {
       empty,
-      loading,
       items,
       sortingColumn,
       sortingDescending,
@@ -63,7 +62,6 @@ const Table = React.forwardRef<CollectionRef, TableProps>(
     }));
     return (
       <div>
-        <div data-testid="loading">{String(loading)}</div>
         <div data-testid="sortedby">
           {((sortingColumn && sortingColumn.sortingField) || '') + !!sortingDescending ? ' descending' : ''}
         </div>

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -96,7 +96,6 @@ interface UseCollectionResultBase<T> {
   actions: CollectionActions<T>;
   collectionProps: {
     empty?: React.ReactNode;
-    loading?: boolean;
     onSortingChange?(event: CustomEvent<SortingState<T>>): void;
     sortingColumn?: SortingColumn<T>;
     sortingDescending?: boolean;


### PR DESCRIPTION
This property is part of the interface, but not passed in the return value. It has caused confusion about the existence on client side filtering, which is why we are removing it. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.