### PR TITLE
Use generic property filter operator to enhance operators list

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -28,23 +28,23 @@ export interface SelectionChangeDetail<T> {
 
 export type TrackBy<T> = string | ((item: T) => string);
 
-export type Operator = '<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=';
+export type Operator = '<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=' | 'in';
 export type Operation = 'and' | 'or';
-export interface Token {
+export interface Token<Op extends Operator> {
   value: string;
   propertyKey?: string;
-  operator: Operator;
+  operator: Op;
 }
-export interface Query {
-  tokens: readonly Token[];
+export interface Query<Op extends Operator> {
+  tokens: readonly Token<Op>[];
   operation: Operation;
 }
-export interface FilteringProperty {
+export interface FilteringProperty<Op extends Operator> {
   key: string;
   groupValuesLabel: string;
   propertyLabel: string;
-  operators?: readonly Operator[];
-  defaultOperator?: Operator;
+  operators?: readonly Op[];
+  defaultOperator?: Op;
   group?: string;
 }
 export interface PropertyFilteringOption {
@@ -52,7 +52,7 @@ export interface PropertyFilteringOption {
   value: string;
 }
 
-export interface UseCollectionOptions<T> {
+export interface UseCollectionOptions<T, Op extends Operator> {
   filtering?: FilteringOptions<T> & {
     empty?: React.ReactNode;
     noMatch?: React.ReactNode;
@@ -61,10 +61,10 @@ export interface UseCollectionOptions<T> {
   propertyFiltering?: {
     empty?: React.ReactNode;
     noMatch?: React.ReactNode;
-    filteringProperties: readonly FilteringProperty[];
+    filteringProperties: readonly FilteringProperty<Op>[];
     // custom filtering function
-    filteringFunction?: (item: T, query: Query) => boolean;
-    defaultQuery?: Query;
+    filteringFunction?: (item: T, query: Query<Op>) => boolean;
+    defaultQuery?: Query<Op>;
   };
   sorting?: { defaultState?: SortingState<T> };
   pagination?: { defaultPage?: number; pageSize?: number };
@@ -75,25 +75,25 @@ export interface UseCollectionOptions<T> {
   };
 }
 
-export interface CollectionState<T> {
+export interface CollectionState<T, Op extends Operator> {
   filteringText: string;
-  propertyFilteringQuery: Query;
+  propertyFilteringQuery: Query<Op>;
   currentPageIndex: number;
   sortingState?: SortingState<T>;
   selectedItems: ReadonlyArray<T>;
 }
 
-export interface CollectionActions<T> {
+export interface CollectionActions<T, Op extends Operator> {
   setFiltering(filteringText: string): void;
   setCurrentPage(pageNumber: number): void;
   setSorting(state: SortingState<T>): void;
   setSelectedItems(selectedItems: ReadonlyArray<T>): void;
-  setPropertyFiltering(query: Query): void;
+  setPropertyFiltering(query: Query<Op>): void;
 }
 
-interface UseCollectionResultBase<T> {
+interface UseCollectionResultBase<T, Op extends Operator> {
   items: ReadonlyArray<T>;
-  actions: CollectionActions<T>;
+  actions: CollectionActions<T, Op>;
   collectionProps: {
     empty?: React.ReactNode;
     loading?: boolean;
@@ -111,9 +111,9 @@ interface UseCollectionResultBase<T> {
     onChange(event: CustomEvent<{ filteringText: string }>): void;
   };
   propertyFilterProps: {
-    query: Query;
-    onChange(event: CustomEvent<Query>): void;
-    filteringProperties: readonly FilteringProperty[];
+    query: Query<Op>;
+    onChange(event: CustomEvent<Query<Op>>): void;
+    filteringProperties: readonly FilteringProperty<Op>[];
     filteringOptions: readonly PropertyFilteringOption[];
   };
   paginationProps: {
@@ -123,9 +123,9 @@ interface UseCollectionResultBase<T> {
   };
 }
 
-export interface UseCollectionResult<T> extends UseCollectionResultBase<T> {
+export interface UseCollectionResult<T, Op extends Operator = Operator> extends UseCollectionResultBase<T, Op> {
   filteredItemsCount: number | undefined;
-  paginationProps: UseCollectionResultBase<T>['paginationProps'] & {
+  paginationProps: UseCollectionResultBase<T, Op>['paginationProps'] & {
     pagesCount: number;
   };
 }

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,15 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { UseCollectionOptions, CollectionState, TrackBy } from '../interfaces';
+import { UseCollectionOptions, CollectionState, TrackBy, Operator } from '../interfaces';
 import { filter } from './filter.js';
 import { propertyFilter } from './property-filter.js';
 import { sort } from './sort.js';
 import { getPagesCount, normalizePageIndex, paginate } from './paginate.js';
 
-export function processItems<T>(
+export function processItems<T, Op extends Operator>(
   items: ReadonlyArray<T>,
-  { filteringText, sortingState, currentPageIndex, propertyFilteringQuery }: Partial<CollectionState<T>>,
-  { filtering, sorting, pagination, propertyFiltering }: UseCollectionOptions<T>
+  { filteringText, sortingState, currentPageIndex, propertyFilteringQuery }: Partial<CollectionState<T, Op>>,
+  { filtering, sorting, pagination, propertyFiltering }: UseCollectionOptions<T, Op>
 ): {
   items: ReadonlyArray<T>;
   pagesCount: number | undefined;

--- a/src/use-collection-state.ts
+++ b/src/use-collection-state.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useReducer } from 'react';
 import { createActions, collectionReducer, CollectionReducer } from './utils.js';
-import { UseCollectionOptions, CollectionState, CollectionActions, CollectionRef } from './interfaces';
+import { UseCollectionOptions, CollectionState, CollectionActions, CollectionRef, Operator } from './interfaces';
 
-export function useCollectionState<T>(
-  options: UseCollectionOptions<T>,
+export function useCollectionState<T, Op extends Operator>(
+  options: UseCollectionOptions<T, Op>,
   collectionRef: React.RefObject<CollectionRef>
-): readonly [CollectionState<T>, CollectionActions<T>] {
-  const [state, dispatch] = useReducer<CollectionReducer<T>>(collectionReducer, {
+): readonly [CollectionState<T, Op>, CollectionActions<T, Op>] {
+  const [state, dispatch] = useReducer<CollectionReducer<T, Op>>(collectionReducer, {
     selectedItems: options.selection?.defaultSelectedItems ?? [],
     sortingState: options.sorting?.defaultState,
     currentPageIndex: options.pagination?.defaultPage ?? 1,

--- a/src/use-collection.ts
+++ b/src/use-collection.ts
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useRef } from 'react';
 import { processItems, processSelectedItems, itemsAreEqual } from './operations/index.js';
-import { UseCollectionOptions, UseCollectionResult, CollectionRef } from './interfaces';
+import { UseCollectionOptions, UseCollectionResult, CollectionRef, Operator } from './interfaces';
 import { createSyncProps } from './utils.js';
 import { useCollectionState } from './use-collection-state.js';
 
-export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollectionOptions<T>): UseCollectionResult<T> {
+export function useCollection<T, Op extends Operator = Operator>(
+  allItems: ReadonlyArray<T>,
+  options: UseCollectionOptions<T, Op>
+): UseCollectionResult<T, Op> {
   const collectionRef = useRef<CollectionRef>(null);
   const [state, actions] = useCollectionState(options, collectionRef);
   const { items, pagesCount, filteredItemsCount, actualPageIndex } = processItems(allItems, state, options);


### PR DESCRIPTION
Experiment: Use generic property filter operator to enhance operators list.

This change is necessary to support the new `in` operator type. The type can't be simply updated due to the duplication: the operator type is defined in both collection-hooks and components repos.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
