### PR TITLE
Export property filter props to be used in components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@
     "@typescript-eslint/ban-ts-comment": ["error", { "ts-expect-error": "allow-with-description" }],
     "@typescript-eslint/interface-name-prefix": "off",
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-namespace": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
     "react/display-name": "off",
     "react/prop-types": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,6 @@
     "@typescript-eslint/ban-ts-comment": ["error", { "ts-expect-error": "allow-with-description" }],
     "@typescript-eslint/interface-name-prefix": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-namespace": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
     "react/display-name": "off",
     "react/prop-types": "off",

--- a/src/__tests__/operations/property-filter.test.ts
+++ b/src/__tests__/operations/property-filter.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { processItems } from '../../operations';
-import { PropertyFilter } from '../../interfaces';
+import { PropertyFilterOperator } from '../../interfaces';
 
 const propertyFiltering = {
   filteringProperties: [
@@ -132,7 +132,7 @@ describe('Supported operators', () => {
   items[3].falsy = '';
   items[4].falsy = NaN;
 
-  test.each<[PropertyFilter.Operator, Item[]]>([
+  test.each<[PropertyFilterOperator, Item[]]>([
     [':', [items[2]]],
     ['!:', [items[0], items[1], items[3], items[4]]],
     ['=', [items[2]]],
@@ -154,7 +154,7 @@ describe('Supported operators', () => {
     const { items: processed } = processItems(items, { propertyFilteringQuery: operatorQuery }, { propertyFiltering });
     expect(processed).toEqual([items[3]]);
   });
-  test.each<PropertyFilter.Operator>(['<', '<=', '>', '>=', ':', '!:', '!='])(
+  test.each<PropertyFilterOperator>(['<', '<=', '>', '>=', ':', '!:', '!='])(
     '%s operator is not supported by default',
     operator => {
       const operatorQuery = {

--- a/src/__tests__/operations/property-filter.test.ts
+++ b/src/__tests__/operations/property-filter.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { processItems } from '../../operations';
-import { Operator } from '../../interfaces';
+import { PropertyFilter } from '../../interfaces';
 
 const propertyFiltering = {
   filteringProperties: [
@@ -132,7 +132,7 @@ describe('Supported operators', () => {
   items[3].falsy = '';
   items[4].falsy = NaN;
 
-  test.each<[Operator, Item[]]>([
+  test.each<[PropertyFilter.Operator, Item[]]>([
     [':', [items[2]]],
     ['!:', [items[0], items[1], items[3], items[4]]],
     ['=', [items[2]]],
@@ -154,14 +154,21 @@ describe('Supported operators', () => {
     const { items: processed } = processItems(items, { propertyFilteringQuery: operatorQuery }, { propertyFiltering });
     expect(processed).toEqual([items[3]]);
   });
-  test.each<Operator>(['<', '<=', '>', '>=', ':', '!:', '!='])('%s operator is not supported by default', operator => {
-    const operatorQuery = {
-      tokens: [{ propertyKey: 'default', operator, value: '3' }],
-      operation: 'and',
-    } as const;
-    const { items: processed } = processItems(items, { propertyFilteringQuery: operatorQuery }, { propertyFiltering });
-    expect(processed).toEqual([]);
-  });
+  test.each<PropertyFilter.Operator>(['<', '<=', '>', '>=', ':', '!:', '!='])(
+    '%s operator is not supported by default',
+    operator => {
+      const operatorQuery = {
+        tokens: [{ propertyKey: 'default', operator, value: '3' }],
+        operation: 'and',
+      } as const;
+      const { items: processed } = processItems(
+        items,
+        { propertyFilteringQuery: operatorQuery },
+        { propertyFiltering }
+      );
+      expect(processed).toEqual([]);
+    }
+  );
   describe('treatment of the falsy values', () => {
     test('zero is treated as a number', () => {
       {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,10 @@ export {
   FilteringOptions,
   UseCollectionOptions,
   UseCollectionResult,
-  PropertyFilter,
+  PropertyFilterOperator,
+  PropertyFilterOperation,
+  PropertyFilterToken,
+  PropertyFilterQuery,
+  PropertyFilterProperty,
+  PropertyFilterOption,
 } from './interfaces';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 export { useCollection } from './use-collection.js';
-export { CollectionRef, FilteringOptions, UseCollectionOptions, UseCollectionResult } from './interfaces';
+export {
+  CollectionRef,
+  FilteringOptions,
+  UseCollectionOptions,
+  UseCollectionResult,
+  PropertyFilter,
+} from './interfaces';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -37,10 +37,10 @@ export interface UseCollectionOptions<T> {
   propertyFiltering?: {
     empty?: React.ReactNode;
     noMatch?: React.ReactNode;
-    filteringProperties: readonly PropertyFilter.FilteringProperty[];
+    filteringProperties: readonly PropertyFilterProperty[];
     // custom filtering function
-    filteringFunction?: (item: T, query: PropertyFilter.Query) => boolean;
-    defaultQuery?: PropertyFilter.Query;
+    filteringFunction?: (item: T, query: PropertyFilterQuery) => boolean;
+    defaultQuery?: PropertyFilterQuery;
   };
   sorting?: { defaultState?: SortingState<T> };
   pagination?: { defaultPage?: number; pageSize?: number };
@@ -53,7 +53,7 @@ export interface UseCollectionOptions<T> {
 
 export interface CollectionState<T> {
   filteringText: string;
-  propertyFilteringQuery: PropertyFilter.Query;
+  propertyFilteringQuery: PropertyFilterQuery;
   currentPageIndex: number;
   sortingState?: SortingState<T>;
   selectedItems: ReadonlyArray<T>;
@@ -64,7 +64,7 @@ export interface CollectionActions<T> {
   setCurrentPage(pageNumber: number): void;
   setSorting(state: SortingState<T>): void;
   setSelectedItems(selectedItems: ReadonlyArray<T>): void;
-  setPropertyFiltering(query: PropertyFilter.Query): void;
+  setPropertyFiltering(query: PropertyFilterQuery): void;
 }
 
 interface UseCollectionResultBase<T> {
@@ -87,10 +87,10 @@ interface UseCollectionResultBase<T> {
     onChange(event: CustomEvent<{ filteringText: string }>): void;
   };
   propertyFilterProps: {
-    query: PropertyFilter.Query;
-    onChange(event: CustomEvent<PropertyFilter.Query>): void;
-    filteringProperties: readonly PropertyFilter.FilteringProperty[];
-    filteringOptions: readonly PropertyFilter.FilteringOption[];
+    query: PropertyFilterQuery;
+    onChange(event: CustomEvent<PropertyFilterQuery>): void;
+    filteringProperties: readonly PropertyFilterProperty[];
+    filteringOptions: readonly PropertyFilterOption[];
   };
   paginationProps: {
     disabled?: boolean;
@@ -110,28 +110,27 @@ export interface CollectionRef {
   scrollToTop: () => void;
 }
 
-export namespace PropertyFilter {
-  export type Operator = '<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=';
-  export type Operation = 'and' | 'or';
-  export interface Token {
-    value: string;
-    propertyKey?: string;
-    operator: Operator;
-  }
-  export interface Query {
-    tokens: readonly Token[];
-    operation: Operation;
-  }
-  export interface FilteringProperty {
-    key: string;
-    groupValuesLabel: string;
-    propertyLabel: string;
-    operators?: readonly Operator[];
-    defaultOperator?: Operator;
-    group?: string;
-  }
-  export interface FilteringOption {
-    propertyKey: string;
-    value: string;
-  }
+export type PropertyFilterOperator = '<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=';
+
+export type PropertyFilterOperation = 'and' | 'or';
+export interface PropertyFilterToken {
+  value: string;
+  propertyKey?: string;
+  operator: PropertyFilterOperator;
+}
+export interface PropertyFilterQuery {
+  tokens: readonly PropertyFilterToken[];
+  operation: PropertyFilterOperation;
+}
+export interface PropertyFilterProperty {
+  key: string;
+  groupValuesLabel: string;
+  propertyLabel: string;
+  operators?: readonly PropertyFilterOperator[];
+  defaultOperator?: PropertyFilterOperator;
+  group?: string;
+}
+export interface PropertyFilterOption {
+  propertyKey: string;
+  value: string;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -28,30 +28,6 @@ export interface SelectionChangeDetail<T> {
 
 export type TrackBy<T> = string | ((item: T) => string);
 
-export type Operator = '<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=';
-export type Operation = 'and' | 'or';
-export interface Token {
-  value: string;
-  propertyKey?: string;
-  operator: Operator;
-}
-export interface Query {
-  tokens: readonly Token[];
-  operation: Operation;
-}
-export interface FilteringProperty {
-  key: string;
-  groupValuesLabel: string;
-  propertyLabel: string;
-  operators?: readonly Operator[];
-  defaultOperator?: Operator;
-  group?: string;
-}
-export interface PropertyFilteringOption {
-  propertyKey: string;
-  value: string;
-}
-
 export interface UseCollectionOptions<T> {
   filtering?: FilteringOptions<T> & {
     empty?: React.ReactNode;
@@ -61,10 +37,10 @@ export interface UseCollectionOptions<T> {
   propertyFiltering?: {
     empty?: React.ReactNode;
     noMatch?: React.ReactNode;
-    filteringProperties: readonly FilteringProperty[];
+    filteringProperties: readonly PropertyFilter.FilteringProperty[];
     // custom filtering function
-    filteringFunction?: (item: T, query: Query) => boolean;
-    defaultQuery?: Query;
+    filteringFunction?: (item: T, query: PropertyFilter.Query) => boolean;
+    defaultQuery?: PropertyFilter.Query;
   };
   sorting?: { defaultState?: SortingState<T> };
   pagination?: { defaultPage?: number; pageSize?: number };
@@ -77,7 +53,7 @@ export interface UseCollectionOptions<T> {
 
 export interface CollectionState<T> {
   filteringText: string;
-  propertyFilteringQuery: Query;
+  propertyFilteringQuery: PropertyFilter.Query;
   currentPageIndex: number;
   sortingState?: SortingState<T>;
   selectedItems: ReadonlyArray<T>;
@@ -88,7 +64,7 @@ export interface CollectionActions<T> {
   setCurrentPage(pageNumber: number): void;
   setSorting(state: SortingState<T>): void;
   setSelectedItems(selectedItems: ReadonlyArray<T>): void;
-  setPropertyFiltering(query: Query): void;
+  setPropertyFiltering(query: PropertyFilter.Query): void;
 }
 
 interface UseCollectionResultBase<T> {
@@ -111,10 +87,10 @@ interface UseCollectionResultBase<T> {
     onChange(event: CustomEvent<{ filteringText: string }>): void;
   };
   propertyFilterProps: {
-    query: Query;
-    onChange(event: CustomEvent<Query>): void;
-    filteringProperties: readonly FilteringProperty[];
-    filteringOptions: readonly PropertyFilteringOption[];
+    query: PropertyFilter.Query;
+    onChange(event: CustomEvent<PropertyFilter.Query>): void;
+    filteringProperties: readonly PropertyFilter.FilteringProperty[];
+    filteringOptions: readonly PropertyFilter.FilteringOption[];
   };
   paginationProps: {
     disabled?: boolean;
@@ -132,4 +108,30 @@ export interface UseCollectionResult<T> extends UseCollectionResultBase<T> {
 
 export interface CollectionRef {
   scrollToTop: () => void;
+}
+
+export namespace PropertyFilter {
+  export type Operator = '<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=';
+  export type Operation = 'and' | 'or';
+  export interface Token {
+    value: string;
+    propertyKey?: string;
+    operator: Operator;
+  }
+  export interface Query {
+    tokens: readonly Token[];
+    operation: Operation;
+  }
+  export interface FilteringProperty {
+    key: string;
+    groupValuesLabel: string;
+    propertyLabel: string;
+    operators?: readonly Operator[];
+    defaultOperator?: Operator;
+    group?: string;
+  }
+  export interface FilteringOption {
+    propertyKey: string;
+    value: string;
+  }
 }

--- a/src/operations/property-filter.ts
+++ b/src/operations/property-filter.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { UseCollectionOptions, Operator, Query, Token } from '../interfaces';
+import { UseCollectionOptions, PropertyFilter } from '../interfaces';
 
-const filterUsingOperator = (itemValue: any, tokenValue: string, operator: Operator) => {
+const filterUsingOperator = (itemValue: any, tokenValue: string, operator: PropertyFilter.Operator) => {
   switch (operator) {
     case '<':
       return itemValue < tokenValue;
@@ -28,7 +28,7 @@ const filterUsingOperator = (itemValue: any, tokenValue: string, operator: Opera
 function freeTextFilter<T>(
   value: string,
   item: T,
-  operator: Operator,
+  operator: PropertyFilter.Operator,
   filteringPropertiesMap: FilteringPropertiesMap<T>
 ): boolean {
   const matches = Object.keys(filteringPropertiesMap).some(propertyKey => {
@@ -38,7 +38,7 @@ function freeTextFilter<T>(
   return operator === ':' ? matches : !matches;
 }
 
-function filterByToken<T>(token: Token, item: T, filteringPropertiesMap: FilteringPropertiesMap<T>) {
+function filterByToken<T>(token: PropertyFilter.Token, item: T, filteringPropertiesMap: FilteringPropertiesMap<T>) {
   if (token.propertyKey) {
     // token refers to a unknown property or uses an unsupported operator
     if (
@@ -54,7 +54,7 @@ function filterByToken<T>(token: Token, item: T, filteringPropertiesMap: Filteri
 }
 
 function defaultFilteringFunction<T extends Record<string, any>>(filteringPropertiesMap: FilteringPropertiesMap<T>) {
-  return (item: T, { tokens, operation }: Query) => {
+  return (item: T, { tokens, operation }: PropertyFilter.Query) => {
     let result = operation === 'and' ? true : !tokens.length;
     for (const token of tokens) {
       result =
@@ -69,13 +69,13 @@ function defaultFilteringFunction<T extends Record<string, any>>(filteringProper
 export type FilteringPropertiesMap<T> = {
   [key in keyof T]: {
     operators: {
-      [key in Operator]?: true;
+      [key in PropertyFilter.Operator]?: true;
     };
   };
 };
 export function propertyFilter<T>(
   items: ReadonlyArray<T>,
-  query: Query,
+  query: PropertyFilter.Query,
   { filteringFunction, filteringProperties }: NonNullable<UseCollectionOptions<T>['propertyFiltering']>
 ): ReadonlyArray<T> {
   const filteringPropertiesMap = filteringProperties.reduce<FilteringPropertiesMap<T>>(

--- a/src/operations/property-filter.ts
+++ b/src/operations/property-filter.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { UseCollectionOptions, PropertyFilter } from '../interfaces';
+import { PropertyFilterOperator, PropertyFilterQuery, PropertyFilterToken, UseCollectionOptions } from '../interfaces';
 
-const filterUsingOperator = (itemValue: any, tokenValue: string, operator: PropertyFilter.Operator) => {
+const filterUsingOperator = (itemValue: any, tokenValue: string, operator: PropertyFilterOperator) => {
   switch (operator) {
     case '<':
       return itemValue < tokenValue;
@@ -28,7 +28,7 @@ const filterUsingOperator = (itemValue: any, tokenValue: string, operator: Prope
 function freeTextFilter<T>(
   value: string,
   item: T,
-  operator: PropertyFilter.Operator,
+  operator: PropertyFilterOperator,
   filteringPropertiesMap: FilteringPropertiesMap<T>
 ): boolean {
   const matches = Object.keys(filteringPropertiesMap).some(propertyKey => {
@@ -38,7 +38,7 @@ function freeTextFilter<T>(
   return operator === ':' ? matches : !matches;
 }
 
-function filterByToken<T>(token: PropertyFilter.Token, item: T, filteringPropertiesMap: FilteringPropertiesMap<T>) {
+function filterByToken<T>(token: PropertyFilterToken, item: T, filteringPropertiesMap: FilteringPropertiesMap<T>) {
   if (token.propertyKey) {
     // token refers to a unknown property or uses an unsupported operator
     if (
@@ -54,7 +54,7 @@ function filterByToken<T>(token: PropertyFilter.Token, item: T, filteringPropert
 }
 
 function defaultFilteringFunction<T extends Record<string, any>>(filteringPropertiesMap: FilteringPropertiesMap<T>) {
-  return (item: T, { tokens, operation }: PropertyFilter.Query) => {
+  return (item: T, { tokens, operation }: PropertyFilterQuery) => {
     let result = operation === 'and' ? true : !tokens.length;
     for (const token of tokens) {
       result =
@@ -69,13 +69,13 @@ function defaultFilteringFunction<T extends Record<string, any>>(filteringProper
 export type FilteringPropertiesMap<T> = {
   [key in keyof T]: {
     operators: {
-      [key in PropertyFilter.Operator]?: true;
+      [key in PropertyFilterOperator]?: true;
     };
   };
 };
 export function propertyFilter<T>(
   items: ReadonlyArray<T>,
-  query: PropertyFilter.Query,
+  query: PropertyFilterQuery,
   { filteringFunction, filteringProperties }: NonNullable<UseCollectionOptions<T>['propertyFiltering']>
 ): ReadonlyArray<T> {
   const filteringPropertiesMap = filteringProperties.reduce<FilteringPropertiesMap<T>>(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,8 +8,7 @@ import {
   SortingState,
   UseCollectionResult,
   CollectionRef,
-  Query,
-  PropertyFilteringOption,
+  PropertyFilter,
 } from './interfaces';
 import { fixupFalsyValues } from './operations/property-filter.js';
 
@@ -31,7 +30,7 @@ interface FilteringAction {
 }
 interface PropertyFilteringAction {
   type: 'property-filtering';
-  query: Query;
+  query: PropertyFilter.Query;
 }
 type Action<T> = SelectionAction<T> | SortingAction<T> | PaginationAction | FilteringAction | PropertyFilteringAction;
 export type CollectionReducer<T> = Reducer<CollectionState<T>, Action<T>>;
@@ -83,7 +82,7 @@ export function createActions<T>({
     setSelectedItems(selectedItems: Array<T>) {
       dispatch({ type: 'selection', selectedItems });
     },
-    setPropertyFiltering(query: Query) {
+    setPropertyFiltering(query: PropertyFilter.Query) {
       dispatch({ type: 'property-filtering', query });
       collectionRef.current && collectionRef.current.scrollToTop();
     },
@@ -112,7 +111,7 @@ export function createSyncProps<T>(
       : options.propertyFiltering.empty
     : empty;
   const filteringOptions = options.propertyFiltering
-    ? options.propertyFiltering.filteringProperties.reduce<PropertyFilteringOption[]>((acc, property) => {
+    ? options.propertyFiltering.filteringProperties.reduce<PropertyFilter.FilteringOption[]>((acc, property) => {
         Object.keys(
           allItems.reduce<{ [key in string]: boolean }>((acc, item) => {
             acc['' + fixupFalsyValues(item[property.key as keyof T])] = true;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,8 @@ import {
   SortingState,
   UseCollectionResult,
   CollectionRef,
-  PropertyFilter,
+  PropertyFilterQuery,
+  PropertyFilterOption,
 } from './interfaces';
 import { fixupFalsyValues } from './operations/property-filter.js';
 
@@ -30,7 +31,7 @@ interface FilteringAction {
 }
 interface PropertyFilteringAction {
   type: 'property-filtering';
-  query: PropertyFilter.Query;
+  query: PropertyFilterQuery;
 }
 type Action<T> = SelectionAction<T> | SortingAction<T> | PaginationAction | FilteringAction | PropertyFilteringAction;
 export type CollectionReducer<T> = Reducer<CollectionState<T>, Action<T>>;
@@ -82,7 +83,7 @@ export function createActions<T>({
     setSelectedItems(selectedItems: Array<T>) {
       dispatch({ type: 'selection', selectedItems });
     },
-    setPropertyFiltering(query: PropertyFilter.Query) {
+    setPropertyFiltering(query: PropertyFilterQuery) {
       dispatch({ type: 'property-filtering', query });
       collectionRef.current && collectionRef.current.scrollToTop();
     },
@@ -111,7 +112,7 @@ export function createSyncProps<T>(
       : options.propertyFiltering.empty
     : empty;
   const filteringOptions = options.propertyFiltering
-    ? options.propertyFiltering.filteringProperties.reduce<PropertyFilter.FilteringOption[]>((acc, property) => {
+    ? options.propertyFiltering.filteringProperties.reduce<PropertyFilterOption[]>((acc, property) => {
         Object.keys(
           allItems.reduce<{ [key in string]: boolean }>((acc, item) => {
             acc['' + fixupFalsyValues(item[property.key as keyof T])] = true;


### PR DESCRIPTION
Exporting property-filter props to deduplicate their definition between components and collection-hooks. Once merged, the types will be consumed by the components package, replacing the existing ones here: https://github.com/cloudscape-design/components/blob/main/src/property-filter/interfaces.ts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
