### PR TITLE
fix types assignability for custom event arguments

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,7 +3,7 @@
 import * as React from 'react';
 
 // shim for dom types
-interface CustomEvent<T> {
+interface CustomEventLike<T> {
   detail: T;
 }
 
@@ -72,29 +72,29 @@ interface UseCollectionResultBase<T, P extends PropertyFilterProperty> {
   actions: CollectionActions<T>;
   collectionProps: {
     empty?: React.ReactNode;
-    onSortingChange?(event: CustomEvent<SortingState<T>>): void;
+    onSortingChange?(event: CustomEventLike<SortingState<T>>): void;
     sortingColumn?: SortingColumn<T>;
     sortingDescending?: boolean;
     selectedItems?: ReadonlyArray<T>;
-    onSelectionChange?(event: CustomEvent<SelectionChangeDetail<T>>): void;
+    onSelectionChange?(event: CustomEventLike<SelectionChangeDetail<T>>): void;
     trackBy?: string | ((item: T) => string);
     ref: React.RefObject<CollectionRef>;
   };
   filterProps: {
     disabled?: boolean;
     filteringText: string;
-    onChange(event: CustomEvent<{ filteringText: string }>): void;
+    onChange(event: CustomEventLike<{ filteringText: string }>): void;
   };
   propertyFilterProps: {
     query: PropertyFilterQuery;
-    onChange(event: CustomEvent<PropertyFilterQuery>): void;
+    onChange(event: CustomEventLike<PropertyFilterQuery>): void;
     filteringProperties: readonly P[];
     filteringOptions: readonly PropertyFilterOption[];
   };
   paginationProps: {
     disabled?: boolean;
     currentPageIndex: number;
-    onChange(event: CustomEvent<{ currentPageIndex: number }>): void;
+    onChange(event: CustomEventLike<{ currentPageIndex: number }>): void;
   };
 }
 


### PR DESCRIPTION
*Description of changes:*

Current code fails in this use-case:

```js
const interceptedOnSelectionChange: TableProps['onSelectionChange'] = event => {
   collectionProps.onSelectionChange(event); // assignability error here, because our argument is not cancelable, but collection hook wants it cancelable
   myCustomOnChange(event);
}


<Table {...collectionProps} onSelectionChange={interceptedOnSelectionChange} />
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
