### PR TITLE
Fix collection options types

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -28,7 +28,7 @@ export interface SelectionChangeDetail<T> {
 
 export type TrackBy<T> = string | ((item: T) => string);
 
-export interface UseCollectionOptions<T, P extends PropertyFilterProperty = PropertyFilterProperty> {
+export interface UseCollectionOptions<T, P extends PropertyFilterProperty = any> {
   filtering?: FilteringOptions<T> & {
     empty?: React.ReactNode;
     noMatch?: React.ReactNode;
@@ -67,7 +67,7 @@ export interface CollectionActions<T> {
   setPropertyFiltering(query: PropertyFilterQuery): void;
 }
 
-interface UseCollectionResultBase<T, P extends PropertyFilterProperty> {
+interface UseCollectionResultBase<T, P> {
   items: ReadonlyArray<T>;
   actions: CollectionActions<T>;
   collectionProps: {
@@ -98,8 +98,7 @@ interface UseCollectionResultBase<T, P extends PropertyFilterProperty> {
   };
 }
 
-export interface UseCollectionResult<T, P extends PropertyFilterProperty = PropertyFilterProperty>
-  extends UseCollectionResultBase<T, P> {
+export interface UseCollectionResult<T, P extends PropertyFilterProperty = any> extends UseCollectionResultBase<T, P> {
   filteredItemsCount: number | undefined;
   paginationProps: UseCollectionResultBase<T, P>['paginationProps'] & {
     pagesCount: number;

--- a/src/operations/property-filter.ts
+++ b/src/operations/property-filter.ts
@@ -1,7 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { PropertyFilterProperty } from '..';
-import { PropertyFilterOperator, PropertyFilterQuery, PropertyFilterToken, UseCollectionOptions } from '../interfaces';
+
+import {
+  PropertyFilterProperty,
+  PropertyFilterOperator,
+  PropertyFilterQuery,
+  PropertyFilterToken,
+  UseCollectionOptions,
+} from '../interfaces';
 
 const filterUsingOperator = (itemValue: any, tokenValue: string, operator: PropertyFilterOperator) => {
   switch (operator) {
@@ -80,14 +86,7 @@ export function propertyFilter<T>(
   { filteringFunction, filteringProperties }: NonNullable<UseCollectionOptions<T>['propertyFiltering']>
 ): ReadonlyArray<T> {
   const filteringPropertiesMap = filteringProperties.reduce<FilteringPropertiesMap<T>>(
-    (
-      acc: FilteringPropertiesMap<T>,
-      {
-        key,
-        operators,
-        defaultOperator,
-      }: NonNullable<UseCollectionOptions<T, PropertyFilterProperty>['propertyFiltering']>['filteringProperties'][0]
-    ) => {
+    (acc: FilteringPropertiesMap<T>, { key, operators, defaultOperator }: PropertyFilterProperty) => {
       const operatorSet: { [key: string]: true } = { [defaultOperator ?? '=']: true };
       operators?.forEach(op => (operatorSet[op] = true));
       acc[key as keyof T] = {

--- a/src/operations/property-filter.ts
+++ b/src/operations/property-filter.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { PropertyFilterProperty } from '..';
 import { PropertyFilterOperator, PropertyFilterQuery, PropertyFilterToken, UseCollectionOptions } from '../interfaces';
 
 const filterUsingOperator = (itemValue: any, tokenValue: string, operator: PropertyFilterOperator) => {
@@ -85,7 +86,7 @@ export function propertyFilter<T>(
         key,
         operators,
         defaultOperator,
-      }: NonNullable<UseCollectionOptions<T>['propertyFiltering']>['filteringProperties'][0]
+      }: NonNullable<UseCollectionOptions<T, PropertyFilterProperty>['propertyFiltering']>['filteringProperties'][0]
     ) => {
       const operatorSet: { [key: string]: true } = { [defaultOperator ?? '=']: true };
       operators?.forEach(op => (operatorSet[op] = true));


### PR DESCRIPTION
Fix collection options types issue caused by using generic filtering properties.

When `UseCollectionOptions` or `UseCollectionResult` types are used explicitly the filtering properties were automatically parametrised with `PropertyFilterProperty` which is no longer compatible with [PropertyFilterProps.FilteringProperty](https://github.com/cloudscape-design/components/blob/main/src/property-filter/interfaces.ts#L157).

See:

```js
import { useCollection, UseCollectionOptions } from '@cloudscape-design/collection-hooks';
import PropertyFilter, { PropertyFilterProps } from '@cloudscape-design/components/property-filter';

function Demo1() {
  const { ..., propertyFilterProps } = useCollection(items, options)
  return <PropertyFilter {...propertyFilterProps} ... /> // works
}

function Demo2() {
  const { ..., propertyFilterProps } = useCollection(items, options as UseCollectionOptions<ItemType, PropertyFilterProps.FilteringProperty>)
  return <PropertyFilter {...propertyFilterProps} ... /> // works
}

function Demo3() {
  const { ..., propertyFilterProps } = useCollection(items, options as UseCollectionOptions<ItemType>)
  return <PropertyFilter {...propertyFilterProps} ... /> // Error: PropertyFilterProperty != PropertyFilterProps.FilteringProperty
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
