### PR TITLE
Revert "Make filtering property a generic type for use-collection input/output

### DIFF
--- a/src/__tests__/operations/property-filter.test.ts
+++ b/src/__tests__/operations/property-filter.test.ts
@@ -8,29 +8,43 @@ const propertyFiltering = {
     {
       key: 'id',
       operators: [':', '!:'],
+      groupValuesLabel: 'Id values',
+      propertyLabel: 'Id',
     },
     {
       key: 'field',
       operators: [':', '!:'],
+      groupValuesLabel: 'Field values',
+      propertyLabel: 'Field',
     },
     {
       key: 'anotherField',
       operators: [':'],
+      groupValuesLabel: 'Another field values',
+      propertyLabel: 'Another field',
     },
     {
       key: 'number',
       operators: [':', '!:', '=', '!=', '<', '<=', '>', '>='],
+      groupValuesLabel: 'Number values',
+      propertyLabel: 'Number',
     },
     {
       key: 'default',
+      groupValuesLabel: 'Default values',
+      propertyLabel: 'Default',
     },
     {
       key: 'falsy',
       operators: [':', '!:', '=', '!=', '<', '<=', '>', '>='],
+      groupValuesLabel: 'Falsy values',
+      propertyLabel: 'Falsy',
     },
     {
       key: 'bool',
       operators: [':', '!:', '=', '!=', '<', '<=', '>', '>='],
+      groupValuesLabel: 'Boolean values',
+      propertyLabel: 'Boolean',
     },
   ],
 } as const;

--- a/src/__tests__/stubs.tsx
+++ b/src/__tests__/stubs.tsx
@@ -153,9 +153,11 @@ function PropertyFilter({
         ))}
       </ul>
       <ul data-testid="filtering-properties">
-        {filteringProperties.map(({ key, operators }, index) => (
+        {filteringProperties.map(({ key, groupValuesLabel, propertyLabel, operators }, index) => (
           <li id={`property-${index}`} key={index}>
             <span className="key">{key}</span>
+            <span className="values-label">{groupValuesLabel}</span>
+            <span className="property-label">{propertyLabel}</span>
             <span className="operators">{operators?.join(',')}</span>
           </li>
         ))}

--- a/src/__tests__/use-collection.test.tsx
+++ b/src/__tests__/use-collection.test.tsx
@@ -327,6 +327,8 @@ describe('Property filtering', () => {
       {
         key: 'id',
         operators: [':', '!:', '=', '!='],
+        groupValuesLabel: 'Id values',
+        propertyLabel: 'Id',
       },
     ],
     empty: 'No items to display',
@@ -431,9 +433,13 @@ describe('Property filtering', () => {
       filteringProperties: [
         {
           key: 'id',
+          groupValuesLabel: 'Id values',
+          propertyLabel: 'Id',
         },
         {
           key: 'date',
+          groupValuesLabel: 'Date values',
+          propertyLabel: 'Date',
         },
       ],
     } as const;
@@ -457,6 +463,8 @@ describe('Property filtering', () => {
         filteringProperties: [
           {
             key: 'property',
+            groupValuesLabel: 'Property values',
+            propertyLabel: 'Property',
           },
         ],
       } as const;
@@ -477,6 +485,8 @@ describe('Property filtering', () => {
         filteringProperties: [
           {
             key: 'falsy',
+            groupValuesLabel: 'Falsy values',
+            propertyLabel: 'Falsy',
           },
         ],
       } as const;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -28,7 +28,7 @@ export interface SelectionChangeDetail<T> {
 
 export type TrackBy<T> = string | ((item: T) => string);
 
-export interface UseCollectionOptions<T, P extends PropertyFilterProperty = PropertyFilterProperty> {
+export interface UseCollectionOptions<T> {
   filtering?: FilteringOptions<T> & {
     empty?: React.ReactNode;
     noMatch?: React.ReactNode;
@@ -37,7 +37,7 @@ export interface UseCollectionOptions<T, P extends PropertyFilterProperty = Prop
   propertyFiltering?: {
     empty?: React.ReactNode;
     noMatch?: React.ReactNode;
-    filteringProperties: readonly P[];
+    filteringProperties: readonly PropertyFilterProperty[];
     // custom filtering function
     filteringFunction?: (item: T, query: PropertyFilterQuery) => boolean;
     defaultQuery?: PropertyFilterQuery;
@@ -67,7 +67,7 @@ export interface CollectionActions<T> {
   setPropertyFiltering(query: PropertyFilterQuery): void;
 }
 
-interface UseCollectionResultBase<T, P extends PropertyFilterProperty> {
+interface UseCollectionResultBase<T> {
   items: ReadonlyArray<T>;
   actions: CollectionActions<T>;
   collectionProps: {
@@ -88,7 +88,7 @@ interface UseCollectionResultBase<T, P extends PropertyFilterProperty> {
   propertyFilterProps: {
     query: PropertyFilterQuery;
     onChange(event: CustomEventLike<PropertyFilterQuery>): void;
-    filteringProperties: readonly P[];
+    filteringProperties: readonly PropertyFilterProperty[];
     filteringOptions: readonly PropertyFilterOption[];
   };
   paginationProps: {
@@ -98,10 +98,9 @@ interface UseCollectionResultBase<T, P extends PropertyFilterProperty> {
   };
 }
 
-export interface UseCollectionResult<T, P extends PropertyFilterProperty = PropertyFilterProperty>
-  extends UseCollectionResultBase<T, P> {
+export interface UseCollectionResult<T> extends UseCollectionResultBase<T> {
   filteredItemsCount: number | undefined;
-  paginationProps: UseCollectionResultBase<T, P>['paginationProps'] & {
+  paginationProps: UseCollectionResultBase<T>['paginationProps'] & {
     pagesCount: number;
   };
 }
@@ -124,8 +123,11 @@ export interface PropertyFilterQuery {
 }
 export interface PropertyFilterProperty {
   key: string;
+  groupValuesLabel: string;
+  propertyLabel: string;
   operators?: readonly PropertyFilterOperator[];
   defaultOperator?: PropertyFilterOperator;
+  group?: string;
 }
 export interface PropertyFilterOption {
   propertyKey: string;

--- a/src/use-collection-state.ts
+++ b/src/use-collection-state.ts
@@ -2,16 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useReducer } from 'react';
 import { createActions, collectionReducer, CollectionReducer } from './utils.js';
-import {
-  UseCollectionOptions,
-  CollectionState,
-  CollectionActions,
-  CollectionRef,
-  PropertyFilterProperty,
-} from './interfaces';
+import { UseCollectionOptions, CollectionState, CollectionActions, CollectionRef } from './interfaces';
 
-export function useCollectionState<T, P extends PropertyFilterProperty>(
-  options: UseCollectionOptions<T, P>,
+export function useCollectionState<T>(
+  options: UseCollectionOptions<T>,
   collectionRef: React.RefObject<CollectionRef>
 ): readonly [CollectionState<T>, CollectionActions<T>] {
   const [state, dispatch] = useReducer<CollectionReducer<T>>(collectionReducer, {

--- a/src/use-collection.ts
+++ b/src/use-collection.ts
@@ -2,14 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useRef } from 'react';
 import { processItems, processSelectedItems, itemsAreEqual } from './operations/index.js';
-import { UseCollectionOptions, UseCollectionResult, CollectionRef, PropertyFilterProperty } from './interfaces';
+import { UseCollectionOptions, UseCollectionResult, CollectionRef } from './interfaces';
 import { createSyncProps } from './utils.js';
 import { useCollectionState } from './use-collection-state.js';
 
-export function useCollection<T, P extends PropertyFilterProperty = PropertyFilterProperty>(
-  allItems: ReadonlyArray<T>,
-  options: UseCollectionOptions<T, P>
-): UseCollectionResult<T, P> {
+export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollectionOptions<T>): UseCollectionResult<T> {
   const collectionRef = useRef<CollectionRef>(null);
   const [state, actions] = useCollectionState(options, collectionRef);
   const { items, pagesCount, filteredItemsCount, actualPageIndex } = processItems(allItems, state, options);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,6 @@ import {
   CollectionRef,
   PropertyFilterQuery,
   PropertyFilterOption,
-  PropertyFilterProperty,
 } from './interfaces';
 import { fixupFalsyValues } from './operations/property-filter.js';
 
@@ -91,8 +90,8 @@ export function createActions<T>({
   };
 }
 
-export function createSyncProps<T, P extends PropertyFilterProperty>(
-  options: UseCollectionOptions<T, P>,
+export function createSyncProps<T>(
+  options: UseCollectionOptions<T>,
   { filteringText, sortingState, selectedItems, currentPageIndex, propertyFilteringQuery }: CollectionState<T>,
   actions: CollectionActions<T>,
   collectionRef: React.RefObject<CollectionRef>,
@@ -101,7 +100,7 @@ export function createSyncProps<T, P extends PropertyFilterProperty>(
     actualPageIndex,
     allItems,
   }: { pagesCount?: number; actualPageIndex?: number; allItems: ReadonlyArray<T> }
-): Pick<UseCollectionResult<T, P>, 'collectionProps' | 'filterProps' | 'paginationProps' | 'propertyFilterProps'> {
+): Pick<UseCollectionResult<T>, 'collectionProps' | 'filterProps' | 'paginationProps' | 'propertyFilterProps'> {
   let empty: ReactNode | null = options.filtering
     ? allItems.length
       ? options.filtering.noMatch


### PR DESCRIPTION
This reverts commit ad5bd0759d9e7387dbf7f5db949301fc153b86bb.

Reverting as it causes TS errors on customers end.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
