### PR TITLE
Make custom operator form filter optional

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -129,7 +129,7 @@ export type PropertyFilterOperatorMatchCustom<TokenValue> = (itemValue: unknown,
 export interface PropertyFilterOperatorFormProps<TokenValue> {
   value: null | TokenValue;
   onChange: (value: null | TokenValue) => void;
-  filter: string;
+  filter?: string;
   operator: PropertyFilterOperator;
 }
 


### PR DESCRIPTION
When the form is rendered inside the token editor there is no filter possible. Making it `undefined` makes this better explicit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
