### PR TITLE
Preserve original item value when filtering with custom operator matcher

### DIFF
--- a/src/__tests__/operations/property-filter.test.ts
+++ b/src/__tests__/operations/property-filter.test.ts
@@ -327,6 +327,7 @@ describe('extended operators', () => {
   const items = Array.from({ length: 5 }, (_, index) => ({
     number: index,
     default: index + '',
+    boolean: index % 2 === 0,
     date: new Date(`2020-01-0${index + 1}T12:00:00.123`),
     timestamp: new Date(`2020-01-01T0${index}:00:00.123`),
   })) as readonly Item[];
@@ -382,6 +383,31 @@ describe('extended operators', () => {
       }
     );
     expect(processed).toEqual([items[1], items[2]]);
+  });
+
+  test('preserves falsy item values', () => {
+    const { items: processed } = processItems(
+      items,
+      {
+        propertyFilteringQuery: {
+          tokens: [{ propertyKey: 'boolean', operator: '=', value: true }],
+          operation: 'and',
+        },
+      },
+      {
+        propertyFiltering: {
+          filteringProperties: [
+            {
+              key: 'boolean',
+              operators: [{ operator: '=', match: (itemValue, tokenValue) => itemValue === tokenValue }],
+              propertyLabel: '',
+              groupValuesLabel: '',
+            },
+          ],
+        },
+      }
+    );
+    expect(processed).toEqual([items[0], items[2], items[4]]);
   });
 
   test.each([

--- a/src/operations/property-filter.ts
+++ b/src/operations/property-filter.ts
@@ -86,9 +86,11 @@ function filterByToken<T>(token: PropertyFilterToken, item: T, filteringProperti
     ) {
       return false;
     }
-    const itemValue: any = fixupFalsyValues(item[token.propertyKey as keyof T]);
     const operator =
       filteringPropertiesMap[token.propertyKey as keyof FilteringPropertiesMap<T>].operators[token.operator];
+    const itemValue: any = operator?.match
+      ? item[token.propertyKey as keyof T]
+      : fixupFalsyValues(item[token.propertyKey as keyof T]);
     return filterUsingOperator(itemValue, token.value, operator ?? { operator: token.operator });
   }
   return freeTextFilter(token.value, item, token.operator, filteringPropertiesMap);


### PR DESCRIPTION
Preserve original item value when filtering with custom operator matcher. W/o the change the fasly item values such as `false` can be formatted to a string, affecting the match result.
