### PR TITLE
Expose unpaginated items in the use collection result

### DIFF
--- a/src/__tests__/operations/combined.test.ts
+++ b/src/__tests__/operations/combined.test.ts
@@ -16,7 +16,8 @@ test('filtering with pagination', () => {
     { id: 10, value: 'match' },
   ];
   const {
-    items: processed,
+    items: result,
+    unpaginatedItems: unpaginatedResult,
     pagesCount,
     filteredItemsCount,
   } = processItems(
@@ -26,7 +27,8 @@ test('filtering with pagination', () => {
   );
   expect(pagesCount).toEqual(2);
   expect(filteredItemsCount).toEqual(7);
-  expect(processed).toEqual([items[8], items[9]]);
+  expect(result).toEqual([items[8], items[9]]);
+  expect(unpaginatedResult).toEqual(items.filter(it => it.value === 'match'));
 });
 
 test('filtering with sorting', () => {

--- a/src/__tests__/operations/combined.test.ts
+++ b/src/__tests__/operations/combined.test.ts
@@ -17,7 +17,7 @@ test('filtering with pagination', () => {
   ];
   const {
     items: result,
-    unpaginatedItems: unpaginatedResult,
+    allPageItems: allPageResult,
     pagesCount,
     filteredItemsCount,
   } = processItems(
@@ -28,7 +28,7 @@ test('filtering with pagination', () => {
   expect(pagesCount).toEqual(2);
   expect(filteredItemsCount).toEqual(7);
   expect(result).toEqual([items[8], items[9]]);
-  expect(unpaginatedResult).toEqual(items.filter(it => it.value === 'match'));
+  expect(allPageResult).toEqual(items.filter(it => it.value === 'match'));
 });
 
 test('filtering with sorting', () => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -69,6 +69,7 @@ export interface CollectionActions<T> {
 
 interface UseCollectionResultBase<T> {
   items: ReadonlyArray<T>;
+  unpaginatedItems: ReadonlyArray<T>;
   actions: CollectionActions<T>;
   collectionProps: {
     empty?: React.ReactNode;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -69,7 +69,7 @@ export interface CollectionActions<T> {
 
 interface UseCollectionResultBase<T> {
   items: ReadonlyArray<T>;
-  unpaginatedItems: ReadonlyArray<T>;
+  allPageItems: ReadonlyArray<T>;
   actions: CollectionActions<T>;
   collectionProps: {
     empty?: React.ReactNode;

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -12,6 +12,7 @@ export function processItems<T>(
   { filtering, sorting, pagination, propertyFiltering }: UseCollectionOptions<T>
 ): {
   items: ReadonlyArray<T>;
+  unpaginatedItems: ReadonlyArray<T>;
   pagesCount: number | undefined;
   actualPageIndex: number | undefined;
   filteredItemsCount: number | undefined;
@@ -35,13 +36,14 @@ export function processItems<T>(
     result = sort(result, sortingState);
   }
 
+  const unpaginatedResult = result;
   if (pagination) {
     pagesCount = getPagesCount(result, pagination.pageSize);
     actualPageIndex = normalizePageIndex(currentPageIndex, pagesCount);
     result = paginate(result, actualPageIndex, pagination.pageSize);
   }
 
-  return { items: result, pagesCount, filteredItemsCount, actualPageIndex };
+  return { items: result, unpaginatedItems: unpaginatedResult, pagesCount, filteredItemsCount, actualPageIndex };
 }
 
 export const getTrackableValue = <T>(trackBy: TrackBy<T> | undefined, item: T) => {

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -12,7 +12,7 @@ export function processItems<T>(
   { filtering, sorting, pagination, propertyFiltering }: UseCollectionOptions<T>
 ): {
   items: ReadonlyArray<T>;
-  unpaginatedItems: ReadonlyArray<T>;
+  allPageItems: ReadonlyArray<T>;
   pagesCount: number | undefined;
   actualPageIndex: number | undefined;
   filteredItemsCount: number | undefined;
@@ -36,14 +36,14 @@ export function processItems<T>(
     result = sort(result, sortingState);
   }
 
-  const unpaginatedResult = result;
+  const allPageResult = result;
   if (pagination) {
     pagesCount = getPagesCount(result, pagination.pageSize);
     actualPageIndex = normalizePageIndex(currentPageIndex, pagesCount);
     result = paginate(result, actualPageIndex, pagination.pageSize);
   }
 
-  return { items: result, unpaginatedItems: unpaginatedResult, pagesCount, filteredItemsCount, actualPageIndex };
+  return { items: result, allPageItems: allPageResult, pagesCount, filteredItemsCount, actualPageIndex };
 }
 
 export const getTrackableValue = <T>(trackBy: TrackBy<T> | undefined, item: T) => {

--- a/src/use-collection.ts
+++ b/src/use-collection.ts
@@ -9,7 +9,7 @@ import { useCollectionState } from './use-collection-state.js';
 export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollectionOptions<T>): UseCollectionResult<T> {
   const collectionRef = useRef<CollectionRef>(null);
   const [state, actions] = useCollectionState(options, collectionRef);
-  const { items, unpaginatedItems, pagesCount, filteredItemsCount, actualPageIndex } = processItems(
+  const { items, allPageItems, pagesCount, filteredItemsCount, actualPageIndex } = processItems(
     allItems,
     state,
     options
@@ -24,7 +24,7 @@ export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollect
   }
   return {
     items,
-    unpaginatedItems,
+    allPageItems,
     filteredItemsCount,
     actions,
     ...createSyncProps(options, state, actions, collectionRef, {

--- a/src/use-collection.ts
+++ b/src/use-collection.ts
@@ -9,7 +9,11 @@ import { useCollectionState } from './use-collection-state.js';
 export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollectionOptions<T>): UseCollectionResult<T> {
   const collectionRef = useRef<CollectionRef>(null);
   const [state, actions] = useCollectionState(options, collectionRef);
-  const { items, pagesCount, filteredItemsCount, actualPageIndex } = processItems(allItems, state, options);
+  const { items, unpaginatedItems, pagesCount, filteredItemsCount, actualPageIndex } = processItems(
+    allItems,
+    state,
+    options
+  );
   if (options.selection && !options.selection.keepSelection) {
     const newSelectedItems = processSelectedItems(items, state.selectedItems, options.selection.trackBy);
     if (!itemsAreEqual(newSelectedItems, state.selectedItems, options.selection.trackBy)) {
@@ -20,6 +24,7 @@ export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollect
   }
   return {
     items,
+    unpaginatedItems,
     filteredItemsCount,
     actions,
     ...createSyncProps(options, state, actions, collectionRef, {


### PR DESCRIPTION
Exposed unpaginated items to be used for data export.

Ticket: AWSUI-19321

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
