### PR TITLE
chore: Add lint-pr and release-gh-notes workflows

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,12 @@
+name: Lint PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  dry-run:
+    uses: cloudscape-design/.github/.github/workflows/lint-pr.yml@main

--- a/.github/workflows/release-gh-notes.yml
+++ b/.github/workflows/release-gh-notes.yml
@@ -1,0 +1,24 @@
+name: Release Github notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        description: 'Specify the version for this release'
+        type: string
+      npm_package:
+        required: true
+        description: 'npm package of the release repo'
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: cloudscape-design/.github/.github/workflows/release-gh-notes.yml@main
+    secrets: inherit
+    with:
+      npm_package: ${{ github.event.inputs.npm_package }}
+      version: ${{ github.event.inputs.version }}


### PR DESCRIPTION
*Description of changes:*

Add workflows to validate PR title and release github notes. 

both workflows were tested in https://github.com/cloudscape-design/components

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
