### PR TITLE
feat: Add firstIndex and totalItems count to collectionProps

### DIFF
--- a/src/__tests__/stubs.tsx
+++ b/src/__tests__/stubs.tsx
@@ -20,6 +20,8 @@ export function render(jsx: React.ReactElement) {
     getMatchesCount: () => queries.getByTestId('matches-count').textContent,
     getPagesCount: () => queries.getByTestId('pages-count').textContent,
     getCurrentPage: () => queries.getByTestId('current-page').textContent,
+    getRowIndices: () => queries.queryAllByTestId('item').map(element => element.dataset['rowindex']),
+    getTotalItemsCount: () => queries.getByTestId('total-items-count').textContent,
     findFilterInput: () => queries.getByTestId('input') as HTMLInputElement,
     findPropertyFilterChange: () => queries.getByTestId('property-filtering-change') as HTMLButtonElement,
     findPropertyOptions: () => queries.getByTestId('filtering-options').textContent,
@@ -50,6 +52,8 @@ const Table = React.forwardRef<CollectionRef, TableProps>(
       selectedItems,
       onSelectionChange,
       trackBy,
+      firstIndex,
+      totalItemsCount,
       spy,
     }: TableProps,
     ref: React.Ref<CollectionRef>
@@ -83,11 +87,13 @@ const Table = React.forwardRef<CollectionRef, TableProps>(
         </button>
         {items.length === 0 && <div data-testid="empty">{empty}</div>}
         <span data-testid="selected-items">{selectedItems && selectedItems.length}</span>
+        <span data-testid="total-items-count">{totalItemsCount}</span>
         <ul>
-          {items.map(item => (
+          {items.map((item, i) => (
             <li
               key={item.id}
               data-testid="item"
+              data-rowindex={firstIndex ? firstIndex + i : undefined}
               data-selected={
                 selectedItems &&
                 (selectedItems.indexOf(item) !== -1 ||

--- a/src/__tests__/use-collection.test.tsx
+++ b/src/__tests__/use-collection.test.tsx
@@ -546,3 +546,25 @@ describe('Custom matchers', () => {
     expect(getVisibleItems()).toHaveLength(2);
   });
 });
+
+describe('total items count and page range', () => {
+  test('should return the first index of the page', () => {
+    const allItems = generateItems(4);
+    function App() {
+      const result = useCollection<Item>(allItems, { pagination: { pageSize: 2, defaultPage: 2 } });
+      return <Demo {...result} />;
+    }
+    const { getRowIndices } = render(<App />);
+    expect(getRowIndices()).toEqual(['3', '4']);
+  });
+
+  test('should return the correct totalItems of the collection', () => {
+    const allItems = generateItems(4);
+    function App() {
+      const result = useCollection<Item>(allItems, { pagination: { pageSize: 2, defaultPage: 2 } });
+      return <Demo {...result} />;
+    }
+    const { getTotalItemsCount } = render(<App />);
+    expect(getTotalItemsCount()).toEqual('4');
+  });
+});

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -80,6 +80,8 @@ interface UseCollectionResultBase<T> {
     onSelectionChange?(event: CustomEventLike<SelectionChangeDetail<T>>): void;
     trackBy?: string | ((item: T) => string);
     ref: React.RefObject<CollectionRef>;
+    totalItemsCount?: number;
+    firstIndex?: number;
   };
   filterProps: {
     disabled?: boolean;

--- a/src/use-collection.ts
+++ b/src/use-collection.ts
@@ -31,6 +31,7 @@ export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollect
       actualPageIndex,
       pagesCount,
       allItems,
+      allPageItems,
     }),
   };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -99,7 +99,8 @@ export function createSyncProps<T>(
     pagesCount,
     actualPageIndex,
     allItems,
-  }: { pagesCount?: number; actualPageIndex?: number; allItems: ReadonlyArray<T> }
+    allPageItems,
+  }: { pagesCount?: number; actualPageIndex?: number; allItems: ReadonlyArray<T>; allPageItems: ReadonlyArray<T> }
 ): Pick<UseCollectionResult<T>, 'collectionProps' | 'filterProps' | 'paginationProps' | 'propertyFilterProps'> {
   let empty: ReactNode | null = options.filtering
     ? allItems.length
@@ -151,6 +152,12 @@ export function createSyncProps<T>(
           }
         : {}),
       ref: collectionRef,
+      ...(options.pagination?.pageSize
+        ? {
+            totalItemsCount: allPageItems.length,
+            firstIndex: ((actualPageIndex ?? currentPageIndex) - 1) * (options.pagination.pageSize + 1),
+          }
+        : {}),
     },
     filterProps: {
       filteringText,


### PR DESCRIPTION
*Description of changes:*

Add `firstIndex` `totalItemsCount`  properties to `collectionProps`

these properties will be used in https://github.com/cloudscape-design/components/pull/521

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
