### PR TITLE
fix: Calculate firstIndex correctly

### DIFF
--- a/src/__tests__/use-collection.test.tsx
+++ b/src/__tests__/use-collection.test.tsx
@@ -558,6 +558,16 @@ describe('total items count and page range', () => {
     expect(getRowIndices()).toEqual(['3', '4']);
   });
 
+  test('should return the first index of the page for the first page', () => {
+    const allItems = generateItems(4);
+    function App() {
+      const result = useCollection<Item>(allItems, { pagination: { pageSize: 2, defaultPage: 1 } });
+      return <Demo {...result} />;
+    }
+    const { getRowIndices } = render(<App />);
+    expect(getRowIndices()).toEqual(['1', '2']);
+  });
+
   test('should return the correct totalItems of the collection', () => {
     const allItems = generateItems(4);
     function App() {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -155,7 +155,7 @@ export function createSyncProps<T>(
       ...(options.pagination?.pageSize
         ? {
             totalItemsCount: allPageItems.length,
-            firstIndex: ((actualPageIndex ?? currentPageIndex) - 1) * (options.pagination.pageSize + 1),
+            firstIndex: ((actualPageIndex ?? currentPageIndex) - 1) * options.pagination.pageSize + 1,
           }
         : {}),
     },


### PR DESCRIPTION
*Description of changes:*

Calculation for `firstIndex` was wrong, it returned 0 for the first page and increments one on every page.
Ironically the [test case](https://github.com/cloudscape-design/collection-hooks/blob/d3629bd9c9e481059831f4480b26e198a2a2b907/src/__tests__/use-collection.test.tsx#L551) we have was testing the **only** case that would return the correct result which is the second page.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
