### PR TITLE
feat: Deprecate props that go to property definitions API

### DIFF
--- a/src/__tests__/operations/property-filter.test.ts
+++ b/src/__tests__/operations/property-filter.test.ts
@@ -8,43 +8,29 @@ const propertyFiltering = {
     {
       key: 'id',
       operators: [':', '!:'],
-      groupValuesLabel: 'Id values',
-      propertyLabel: 'Id',
     },
     {
       key: 'field',
       operators: [':', '!:'],
-      groupValuesLabel: 'Field values',
-      propertyLabel: 'Field',
     },
     {
       key: 'anotherField',
       operators: [':'],
-      groupValuesLabel: 'Another field values',
-      propertyLabel: 'Another field',
     },
     {
       key: 'number',
       operators: [':', '!:', '=', '!=', '<', '<=', '>', '>='],
-      groupValuesLabel: 'Number values',
-      propertyLabel: 'Number',
     },
     {
       key: 'default',
-      groupValuesLabel: 'Default values',
-      propertyLabel: 'Default',
     },
     {
       key: 'falsy',
       operators: [':', '!:', '=', '!=', '<', '<=', '>', '>='],
-      groupValuesLabel: 'Falsy values',
-      propertyLabel: 'Falsy',
     },
     {
       key: 'bool',
       operators: [':', '!:', '=', '!=', '<', '<=', '>', '>='],
-      groupValuesLabel: 'Boolean values',
-      propertyLabel: 'Boolean',
     },
   ],
 } as const;
@@ -347,8 +333,6 @@ describe('extended operators', () => {
             {
               key: 'number',
               operators: [{ operator: '=' }, { operator: '!=' }],
-              propertyLabel: '',
-              groupValuesLabel: '',
             },
           ],
         },
@@ -375,8 +359,6 @@ describe('extended operators', () => {
                 { operator: '=', match: (value, token) => token.has(value) },
                 { operator: '!=', match: (value, token) => !token.has(value) },
               ],
-              propertyLabel: '',
-              groupValuesLabel: '',
             },
           ],
         },
@@ -400,8 +382,6 @@ describe('extended operators', () => {
             {
               key: 'boolean',
               operators: [{ operator: '=', match: (itemValue, tokenValue) => itemValue === tokenValue }],
-              propertyLabel: '',
-              groupValuesLabel: '',
             },
           ],
         },
@@ -441,8 +421,6 @@ describe('extended operators', () => {
                 { operator: '>=', match: 'date' },
                 { operator: ':', match: 'date' }, // unsupported
               ],
-              propertyLabel: '',
-              groupValuesLabel: '',
             },
           ],
         },
@@ -480,8 +458,6 @@ describe('extended operators', () => {
                 { operator: '>=', match: 'datetime' },
                 { operator: ':', match: 'datetime' }, // unsupported
               ],
-              propertyLabel: '',
-              groupValuesLabel: '',
             },
           ],
         },
@@ -509,8 +485,6 @@ describe('extended operators', () => {
                   { operator: '=', match: 'date-time' as any },
                   { operator: '!=', match: (value, token) => !token.has(value) },
                 ],
-                propertyLabel: '',
-                groupValuesLabel: '',
               },
             ],
           },

--- a/src/__tests__/stubs.tsx
+++ b/src/__tests__/stubs.tsx
@@ -159,11 +159,9 @@ function PropertyFilter({
         ))}
       </ul>
       <ul data-testid="filtering-properties">
-        {filteringProperties.map(({ key, groupValuesLabel, propertyLabel, operators }, index) => (
+        {filteringProperties.map(({ key, operators }, index) => (
           <li id={`property-${index}`} key={index}>
             <span className="key">{key}</span>
-            <span className="values-label">{groupValuesLabel}</span>
-            <span className="property-label">{propertyLabel}</span>
             <span className="operators">{operators?.join(',')}</span>
           </li>
         ))}

--- a/src/__tests__/use-collection.test.tsx
+++ b/src/__tests__/use-collection.test.tsx
@@ -328,8 +328,6 @@ describe('Property filtering', () => {
       {
         key: 'id',
         operators: [':', '!:', '=', '!='],
-        groupValuesLabel: 'Id values',
-        propertyLabel: 'Id',
       },
     ],
     empty: 'No items to display',
@@ -434,13 +432,9 @@ describe('Property filtering', () => {
       filteringProperties: [
         {
           key: 'id',
-          groupValuesLabel: 'Id values',
-          propertyLabel: 'Id',
         },
         {
           key: 'date',
-          groupValuesLabel: 'Date values',
-          propertyLabel: 'Date',
         },
       ],
     } as const;
@@ -464,8 +458,6 @@ describe('Property filtering', () => {
         filteringProperties: [
           {
             key: 'property',
-            groupValuesLabel: 'Property values',
-            propertyLabel: 'Property',
           },
         ],
       } as const;
@@ -486,8 +478,6 @@ describe('Property filtering', () => {
         filteringProperties: [
           {
             key: 'falsy',
-            groupValuesLabel: 'Falsy values',
-            propertyLabel: 'Falsy',
           },
         ],
       } as const;
@@ -525,8 +515,6 @@ describe('Custom matchers', () => {
         { operator: '=', match: (value, tokenValue) => typeof value === 'string' && tokenValue.includes(value) },
         { operator: '!=', match: (value, tokenValue) => typeof value === 'string' && !tokenValue.includes(value) },
       ],
-      propertyLabel: '',
-      groupValuesLabel: '',
     };
     const propertyFiltering = {
       filteringProperties: [statusFilter],

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -117,7 +117,9 @@ export type PropertyFilterOperator = '<' | '<=' | '>' | '>=' | ':' | '!:' | '=' 
 export interface PropertyFilterOperatorExtended<TokenValue> {
   operator: PropertyFilterOperator;
   match?: PropertyFilterOperatorMatch<TokenValue>;
+  // @deprecated - use property definitions instead.
   form?: PropertyFilterOperatorForm<TokenValue>;
+  // @deprecated - use property definitions instead.
   format?: PropertyFilterOperatorFormat<TokenValue>;
 }
 
@@ -154,14 +156,18 @@ export interface PropertyFilterQuery {
 }
 export interface PropertyFilterProperty<TokenValue = any> {
   key: string;
-  groupValuesLabel: string;
-  propertyLabel: string;
   operators?: readonly (PropertyFilterOperator | PropertyFilterOperatorExtended<TokenValue>)[];
   defaultOperator?: PropertyFilterOperator;
+  // @deprecated - use property definitions instead.
+  groupValuesLabel?: string;
+  // @deprecated - use property definitions instead.
+  propertyLabel?: string;
+  // @deprecated - use property definitions instead.
   group?: string;
 }
 export interface PropertyFilterOption {
   propertyKey: string;
   value: string;
+  // @deprecated - use property definitions instead.
   label?: string;
 }


### PR DESCRIPTION
Deprecate property filter related properties that are only relevant for the component itself and not used by the collection hooks.

Required for: https://github.com/cloudscape-design/components/pull/689

Docs: iQATA5oa3qY3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
