### PR TITLE
feat: Added starts-with property filter operator

### DIFF
--- a/src/__tests__/operations/property-filter.test.ts
+++ b/src/__tests__/operations/property-filter.test.ts
@@ -13,7 +13,7 @@ const propertyFiltering = {
     },
     {
       key: 'field',
-      operators: [':', '!:', '^'],
+      operators: [':', '!:', '^', '?'],
       groupValuesLabel: 'Field values',
       propertyLabel: 'Field',
     },
@@ -287,12 +287,31 @@ test('"starts-with" operator matching', () => {
     { id: 3, field: 'match ME too' },
     { id: 4, field: 'match not me' },
   ];
-  const freeTextQuery = {
+  const startsWithQuery = {
     tokens: [{ propertyKey: 'field', operator: '^', value: 'match me' }],
     operation: 'and',
   } as const;
-  const { items: processed } = processItems(items, { propertyFilteringQuery: freeTextQuery }, { propertyFiltering });
+  const { items: processed } = processItems(items, { propertyFilteringQuery: startsWithQuery }, { propertyFiltering });
   expect(processed).toEqual([items[0], items[1], items[2]]);
+});
+
+test('unsupported operator matching', () => {
+  const items = [
+    { id: 1, field: 'match me' },
+    { id: 2, field: 'match mee' },
+    { id: 3, field: 'match ME too' },
+    { id: 4, field: 'match not me' },
+  ];
+  const unsupportedOperatorQuery = {
+    tokens: [{ propertyKey: 'field', operator: '?', value: '???' }],
+    operation: 'and',
+  } as const;
+  const { items: processed } = processItems(
+    items,
+    { propertyFilteringQuery: unsupportedOperatorQuery },
+    { propertyFiltering }
+  );
+  expect(processed).toEqual([items[0], items[1], items[2], items[3]]);
 });
 
 describe('filtering function', () => {

--- a/src/__tests__/operations/property-filter.test.ts
+++ b/src/__tests__/operations/property-filter.test.ts
@@ -7,13 +7,13 @@ const propertyFiltering = {
   filteringProperties: [
     {
       key: 'id',
-      operators: [':', '!:'],
+      operators: [':', '!:', '^='],
       groupValuesLabel: 'Id values',
       propertyLabel: 'Id',
     },
     {
       key: 'field',
-      operators: [':', '!:'],
+      operators: [':', '!:', '^='],
       groupValuesLabel: 'Field values',
       propertyLabel: 'Field',
     },
@@ -154,7 +154,7 @@ describe('Supported operators', () => {
     const { items: processed } = processItems(items, { propertyFilteringQuery: operatorQuery }, { propertyFiltering });
     expect(processed).toEqual([items[3]]);
   });
-  test.each<PropertyFilterOperator>(['<', '<=', '>', '>=', ':', '!:', '!='])(
+  test.each<PropertyFilterOperator>(['<', '<=', '>', '>=', ':', '!:', '!=', '^='])(
     '%s operator is not supported by default',
     operator => {
       const operatorQuery = {
@@ -278,6 +278,21 @@ test('"contains" operator is case-insensitive', () => {
   const freeTextQuery = { tokens: [{ operator: ':', value: 'match me' }], operation: 'and' } as const;
   const { items: processed } = processItems(items, { propertyFilteringQuery: freeTextQuery }, { propertyFiltering });
   expect(processed).toEqual([items[0], items[2]]);
+});
+
+test('"starts-with" operator matching', () => {
+  const items = [
+    { id: 1, field: 'match me' },
+    { id: 2, field: 'match mee' },
+    { id: 3, field: 'match ME too' },
+    { id: 4, field: 'match not me' },
+  ];
+  const freeTextQuery = {
+    tokens: [{ propertyKey: 'field', operator: '^=', value: 'match me' }],
+    operation: 'and',
+  } as const;
+  const { items: processed } = processItems(items, { propertyFilteringQuery: freeTextQuery }, { propertyFiltering });
+  expect(processed).toEqual([items[0], items[1], items[2]]);
 });
 
 describe('filtering function', () => {

--- a/src/__tests__/operations/property-filter.test.ts
+++ b/src/__tests__/operations/property-filter.test.ts
@@ -7,13 +7,13 @@ const propertyFiltering = {
   filteringProperties: [
     {
       key: 'id',
-      operators: [':', '!:', '^='],
+      operators: [':', '!:', '^'],
       groupValuesLabel: 'Id values',
       propertyLabel: 'Id',
     },
     {
       key: 'field',
-      operators: [':', '!:', '^='],
+      operators: [':', '!:', '^'],
       groupValuesLabel: 'Field values',
       propertyLabel: 'Field',
     },
@@ -154,7 +154,7 @@ describe('Supported operators', () => {
     const { items: processed } = processItems(items, { propertyFilteringQuery: operatorQuery }, { propertyFiltering });
     expect(processed).toEqual([items[3]]);
   });
-  test.each<PropertyFilterOperator>(['<', '<=', '>', '>=', ':', '!:', '!=', '^='])(
+  test.each<PropertyFilterOperator>(['<', '<=', '>', '>=', ':', '!:', '!=', '^'])(
     '%s operator is not supported by default',
     operator => {
       const operatorQuery = {
@@ -288,7 +288,7 @@ test('"starts-with" operator matching', () => {
     { id: 4, field: 'match not me' },
   ];
   const freeTextQuery = {
-    tokens: [{ propertyKey: 'field', operator: '^=', value: 'match me' }],
+    tokens: [{ propertyKey: 'field', operator: '^', value: 'match me' }],
     operation: 'and',
   } as const;
   const { items: processed } = processItems(items, { propertyFilteringQuery: freeTextQuery }, { propertyFiltering });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -112,7 +112,7 @@ export interface CollectionRef {
   scrollToTop: () => void;
 }
 
-export type PropertyFilterOperator = '<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=' | '^=';
+export type PropertyFilterOperator = '<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=' | '^';
 
 export interface PropertyFilterOperatorExtended<TokenValue> {
   operator: PropertyFilterOperator;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -112,7 +112,7 @@ export interface CollectionRef {
   scrollToTop: () => void;
 }
 
-export type PropertyFilterOperator = '<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=';
+export type PropertyFilterOperator = '<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=' | '^=';
 
 export interface PropertyFilterOperatorExtended<TokenValue> {
   operator: PropertyFilterOperator;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -112,7 +112,7 @@ export interface CollectionRef {
   scrollToTop: () => void;
 }
 
-export type PropertyFilterOperator = '<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=' | '^';
+export type PropertyFilterOperator = '<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=' | '^' | string;
 
 export interface PropertyFilterOperatorExtended<TokenValue> {
   operator: PropertyFilterOperator;

--- a/src/operations/property-filter.ts
+++ b/src/operations/property-filter.ts
@@ -61,6 +61,9 @@ const filterUsingOperator = (
       return (itemValue + '').toLowerCase().indexOf((tokenValue + '').toLowerCase()) === -1;
     case '^':
       return (itemValue + '').toLowerCase().startsWith((tokenValue + '').toLowerCase());
+    // The unsupported operators result in no data being filtered out.
+    default:
+      return true;
   }
 };
 

--- a/src/operations/property-filter.ts
+++ b/src/operations/property-filter.ts
@@ -59,7 +59,7 @@ const filterUsingOperator = (
       return (itemValue + '').toLowerCase().indexOf((tokenValue + '').toLowerCase()) > -1;
     case '!:':
       return (itemValue + '').toLowerCase().indexOf((tokenValue + '').toLowerCase()) === -1;
-    case '^=':
+    case '^':
       return (itemValue + '').toLowerCase().startsWith((tokenValue + '').toLowerCase());
   }
 };

--- a/src/operations/property-filter.ts
+++ b/src/operations/property-filter.ts
@@ -59,6 +59,8 @@ const filterUsingOperator = (
       return (itemValue + '').toLowerCase().indexOf((tokenValue + '').toLowerCase()) > -1;
     case '!:':
       return (itemValue + '').toLowerCase().indexOf((tokenValue + '').toLowerCase()) === -1;
+    case '^=':
+      return (itemValue + '').toLowerCase().startsWith((tokenValue + '').toLowerCase());
   }
 };
 


### PR DESCRIPTION
Introduced the new starts-with operator (symbol `^`) and changed the operator type to accept any strings which is to support future operator extensions with no changes required for the consumers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
