### PR TITLE
chore: Throw an error when matching against an unsupported property filter operator

### DIFF
--- a/src/__tests__/operations/property-filter.test.ts
+++ b/src/__tests__/operations/property-filter.test.ts
@@ -295,23 +295,15 @@ test('"starts-with" operator matching', () => {
   expect(processed).toEqual([items[0], items[1], items[2]]);
 });
 
-test('unsupported operator matching', () => {
-  const items = [
-    { id: 1, field: 'match me' },
-    { id: 2, field: 'match mee' },
-    { id: 3, field: 'match ME too' },
-    { id: 4, field: 'match not me' },
-  ];
+test('unsupported operator results in an exception', () => {
+  const items = [{ id: 1, field: 'match me' }];
   const unsupportedOperatorQuery = {
     tokens: [{ propertyKey: 'field', operator: '?', value: '???' }],
     operation: 'and',
   } as const;
-  const { items: processed } = processItems(
-    items,
-    { propertyFilteringQuery: unsupportedOperatorQuery },
-    { propertyFiltering }
-  );
-  expect(processed).toEqual([items[0], items[1], items[2], items[3]]);
+  expect(() =>
+    processItems(items, { propertyFilteringQuery: unsupportedOperatorQuery }, { propertyFiltering })
+  ).toThrow('Unsupported operator given.');
 });
 
 describe('filtering function', () => {

--- a/src/operations/property-filter.ts
+++ b/src/operations/property-filter.ts
@@ -61,9 +61,10 @@ const filterUsingOperator = (
       return (itemValue + '').toLowerCase().indexOf((tokenValue + '').toLowerCase()) === -1;
     case '^':
       return (itemValue + '').toLowerCase().startsWith((tokenValue + '').toLowerCase());
-    // The unsupported operators result in no data being filtered out.
+    // The unsupported operators result in an exception being thrown.
+    // The exception can be avoided if using the match function.
     default:
-      return true;
+      throw new Error('Unsupported operator given.');
   }
 };
 


### PR DESCRIPTION
Addressed feedback on https://github.com/cloudscape-design/collection-hooks/pull/51

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
