### PR TITLE
fix: Restore some internal exports used by customers

### DIFF
--- a/src/__tests__/operations/legacy.test.ts
+++ b/src/__tests__/operations/legacy.test.ts
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { sort } from '../../operations/sort';
+import { filter } from '../../operations/filter';
+import { propertyFilter } from '../../operations/property-filter';
+
+const items = [
+  { id: 1, value: 'a' },
+  { id: 2, value: 'ab' },
+  { id: 3, value: 'abc' },
+  { id: 4, value: 'abcd' },
+  { id: 5, value: 'bcd' },
+  { id: 6, value: 'cd' },
+  { id: 7, value: 'd' },
+];
+
+test('legacy sort returns same array when state is empty', () => {
+  const sorted = sort(items, undefined);
+  expect(sorted).toBe(items);
+});
+
+test('legacy sort sorts the array', () => {
+  const sorted = sort([items[2], items[1]], { sortingColumn: { sortingField: 'value' } });
+  expect(sorted).toEqual([items[1], items[2]]);
+});
+
+test('legacy filter returns same array when state is empty', () => {
+  const filtered = filter(items, '', {});
+  expect(filtered).toEqual(items);
+});
+
+test('legacy filter filters the array', () => {
+  const filtered = filter(items, 'bc', {});
+  expect(filtered).toHaveLength(3);
+});
+
+test('legacy property filter returns same array when state is empty', () => {
+  const filtered = propertyFilter(
+    items,
+    { operation: 'and', tokens: [] },
+    { filteringProperties: [{ key: 'value', operators: [':'], propertyLabel: '', groupValuesLabel: '' }] }
+  );
+  expect(filtered).toEqual(items);
+});
+
+test('legacy property filter filters the array', () => {
+  const filtered = propertyFilter(
+    items,
+    { operation: 'and', tokens: [{ operator: ':', value: 'bc' }] },
+    { filteringProperties: [{ key: 'value', operators: [':'], propertyLabel: '', groupValuesLabel: '' }] }
+  );
+  expect(filtered).toHaveLength(3);
+});

--- a/src/operations/filter.ts
+++ b/src/operations/filter.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { UseCollectionOptions } from '../interfaces';
+import { FilteringOptions, UseCollectionOptions } from '../interfaces';
 import { Predicate } from './compose-filters';
 
 function defaultFilteringFunction<T>(item: T, filteringText: string, filteringFields?: string[]) {
@@ -27,4 +27,14 @@ export function createFilterPredicate<T>(
   }
   const filteringFunction = filtering.filteringFunction ?? defaultFilteringFunction;
   return item => filteringFunction(item, filteringText, filtering.fields);
+}
+
+// Keeping this function as there are customers depending on it.
+export function filter<T>(
+  items: ReadonlyArray<T>,
+  filteringText = '',
+  filteringOptions: FilteringOptions<T>
+): ReadonlyArray<T> {
+  const predicate = createFilterPredicate(filteringOptions, filteringText);
+  return predicate ? items.filter(predicate) : items;
 }

--- a/src/operations/property-filter.ts
+++ b/src/operations/property-filter.ts
@@ -163,3 +163,13 @@ export const fixupFalsyValues = <T>(value: T): T | string => {
   }
   return '';
 };
+
+// Keeping this function as there are customers depending on it.
+export function propertyFilter<T>(
+  items: ReadonlyArray<T>,
+  query: PropertyFilterQuery,
+  propertyFiltering: NonNullable<UseCollectionOptions<T>['propertyFiltering']>
+): ReadonlyArray<T> {
+  const predicate = createPropertyFilterPredicate(propertyFiltering, query);
+  return predicate ? items.filter(predicate) : items;
+}

--- a/src/operations/sort.ts
+++ b/src/operations/sort.ts
@@ -32,3 +32,9 @@ export function createComparator<T>(
   const comparator = state.sortingColumn.sortingComparator ?? getSorter(state.sortingColumn.sortingField as keyof T);
   return comparator ? (a, b) => comparator(a, b) * direction : null;
 }
+
+// Keeping this function as there are customers depending on it.
+export function sort<T>(items: ReadonlyArray<T>, state: SortingState<T> | undefined): ReadonlyArray<T> {
+  const comparator = createComparator({}, state);
+  return comparator ? items.slice().sort(comparator) : items;
+}


### PR DESCRIPTION
Restoring until we find a better way to share this code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
