### PR TITLE
fix: Fix handling of NaN for `currentPageIndex`

### DIFF
--- a/src/__tests__/operations/paginate.test.ts
+++ b/src/__tests__/operations/paginate.test.ts
@@ -15,6 +15,8 @@ test('default pagination', () => {
 
 test('should reset the currentPageIndex to 1 when out of range', () => {
   const items = generateItems(25);
+
+  // Page number is above the maximum
   let {
     items: processed,
     pagesCount,
@@ -25,11 +27,23 @@ test('should reset the currentPageIndex to 1 when out of range', () => {
   expect(processed).toHaveLength(10);
   expect(processed[0]).toEqual(items[0]);
 
+  // Page number is below the minimum
   ({
     items: processed,
     pagesCount,
     actualPageIndex,
   } = processItems(items, { currentPageIndex: 0 }, { pagination: {} }));
+  expect(actualPageIndex).toEqual(1);
+  expect(pagesCount).toEqual(3);
+  expect(processed).toHaveLength(10);
+  expect(processed[0]).toEqual(items[0]);
+
+  // Page number is NaN
+  ({
+    items: processed,
+    pagesCount,
+    actualPageIndex,
+  } = processItems(items, { currentPageIndex: NaN }, { pagination: {} }));
   expect(actualPageIndex).toEqual(1);
   expect(pagesCount).toEqual(3);
   expect(processed).toHaveLength(10);

--- a/src/operations/pagination.ts
+++ b/src/operations/pagination.ts
@@ -16,7 +16,7 @@ export function createPageProps<T>(
   const pageSize = pagination.pageSize ?? DEFAULT_PAGE_SIZE;
   const pagesCount = Math.ceil(items.length / pageSize);
   let pageIndex = currentPageIndex ?? 1;
-  if (pageIndex < 1 || pageIndex > pagesCount) {
+  if (pageIndex < 1 || pageIndex > pagesCount || Number.isNaN(pageIndex)) {
     pageIndex = 1;
   }
   return { pageSize, pagesCount, pageIndex };


### PR DESCRIPTION
*Issue #, if available:* AWSUI-27293

*Description of changes:*
The `currentPageIndex` parameter for pagination is a `number` type, which technically means it accepts `NaN` as a value. In that case we should fall back to page 1, like we do when the page number is out of range.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
