### PR TITLE
feat: Configurable operators for free text filtering in property filter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export { useCollection } from './use-collection.js';
 export {
   CollectionRef,
   FilteringOptions,
+  PropertyFilterFreeTextFiltering,
   PropertyFilterOperation,
   PropertyFilterOperator,
   PropertyFilterOperatorExtended,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -41,6 +41,7 @@ export interface UseCollectionOptions<T> {
     // custom filtering function
     filteringFunction?: (item: T, query: PropertyFilterQuery) => boolean;
     defaultQuery?: PropertyFilterQuery;
+    freeTextFiltering?: PropertyFilterFreeTextFiltering;
   };
   sorting?: { defaultState?: SortingState<T> };
   pagination?: { defaultPage?: number; pageSize?: number };
@@ -108,6 +109,7 @@ interface UseCollectionResultBase<T> {
     onChange(event: CustomEventLike<PropertyFilterQuery>): void;
     filteringProperties: readonly PropertyFilterProperty[];
     filteringOptions: readonly PropertyFilterOption[];
+    freeTextFiltering?: PropertyFilterFreeTextFiltering;
   };
   paginationProps: {
     disabled?: boolean;
@@ -179,4 +181,8 @@ export interface PropertyFilterOption {
   propertyKey: string;
   value: string;
   label?: string;
+}
+export interface PropertyFilterFreeTextFiltering {
+  operators?: readonly PropertyFilterOperator[];
+  defaultOperator?: PropertyFilterOperator;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -235,6 +235,7 @@ export function createSyncProps<T>(
       },
       filteringProperties: options.propertyFiltering?.filteringProperties || [],
       filteringOptions,
+      freeTextFiltering: options.propertyFiltering?.freeTextFiltering,
     },
     paginationProps: {
       currentPageIndex: actualPageIndex ?? currentPageIndex,


### PR DESCRIPTION
*Description of changes:* Adding the ability to customize free text filtering operators for the Property Filter, just like every other property operator.
See: k6RfAb8hHR1t

Prototyping this quickly showed the agreed upon API was a perfect 1:1 match for this package, and the change was small enough to jump straight to PR.

Corresponding code change on `@cloudscape-design/components` has [a first prototype here](https://github.com/cloudscape-design/components/compare/main...eudes/property-filter-free-text-operators), pending new unit tests and probably more dev app updates. But I can't submit a clean PR for it until this PR is merged given the direct dependency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
