### PR TITLE
fix: Always provide firstIndex and totalItemsCount in collection result

### DIFF
--- a/src/__tests__/use-collection.test.tsx
+++ b/src/__tests__/use-collection.test.tsx
@@ -576,4 +576,15 @@ describe('total items count and page range', () => {
     const { getTotalItemsCount } = render(<App />);
     expect(getTotalItemsCount()).toEqual('4');
   });
+
+  test('should return first index and totalItems when no pagination', () => {
+    const allItems = generateItems(4);
+    function App() {
+      const result = useCollection<Item>(allItems, {});
+      return <Demo {...result} />;
+    }
+    const { getRowIndices, getTotalItemsCount } = render(<App />);
+    expect(getRowIndices()).toEqual(['1', '2', '3', '4']);
+    expect(getTotalItemsCount()).toEqual('4');
+  });
 });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -96,8 +96,8 @@ interface UseCollectionResultBase<T> {
     };
     trackBy?: string | ((item: T) => string);
     ref: React.RefObject<CollectionRef>;
-    totalItemsCount?: number;
-    firstIndex?: number;
+    totalItemsCount: number;
+    firstIndex: number;
   };
   filterProps: {
     disabled?: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -215,9 +215,10 @@ export function createSyncProps<T>(
           }
         : {}),
       ref: collectionRef,
+      firstIndex: 1,
+      totalItemsCount: allPageItems.length,
       ...(options.pagination?.pageSize
         ? {
-            totalItemsCount: allPageItems.length,
             firstIndex: ((actualPageIndex ?? currentPageIndex) - 1) * options.pagination.pageSize + 1,
           }
         : {}),


### PR DESCRIPTION
The `firstIndex` and `totalItemsCount` properties are used in the Table and Cards components. The properties are needed for `renderAriaLive` announcements and to assign `aria-rowcount` and `aria-rowindex`. While the latter can be omitted when there is no pagination, the live announcements are important regardless because those include the change of the total items count when filtering.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
