### PR TITLE
fix: Expandable rows trackBy to not be overridden with undefined when selection is present

### DIFF
--- a/src/__tests__/use-collection-expadable-rows.test.tsx
+++ b/src/__tests__/use-collection-expadable-rows.test.tsx
@@ -341,3 +341,15 @@ test('selection.trackBy overrides expandableRows.getId', () => {
 
   expect(document.body.textContent).toEqual('22');
 });
+
+test('selection without trackBy does not override expandableRows.trackBy', () => {
+  function App() {
+    const result = useCollection(treeItems, { expandableRows: { getId, getParentId }, selection: {} });
+    return typeof result.collectionProps.trackBy === 'function' ? (
+      <div>{result.collectionProps.trackBy(treeItems[1])}</div>
+    ) : null;
+  }
+  render(<App />);
+
+  expect(document.body.textContent).toEqual('2');
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -211,7 +211,7 @@ export function createSyncProps<T>(
               actions.setSelectedItems(selectedItems);
             },
             selectedItems,
-            trackBy: options.selection.trackBy,
+            trackBy: options.selection.trackBy ?? options.expandableRows?.getId,
           }
         : {}),
       ref: collectionRef,


### PR DESCRIPTION
Fixing a bug when selection config w/o trackBy overrides expandableRows.trackBy with undefined which breaks expandable rows matching in the table.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
