### PR TITLE
chore: POC Enum property type support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export {
   PropertyFilterOperatorMatch,
   PropertyFilterOption,
   PropertyFilterProperty,
+  PropertyFilterTokenType,
   PropertyFilterQuery,
   PropertyFilterToken,
   PropertyFilterTokenGroup,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -133,16 +133,19 @@ export type PropertyFilterOperator = '<' | '<=' | '>' | '>=' | ':' | '!:' | '=' 
 
 export interface PropertyFilterOperatorExtended<TokenValue> {
   operator: PropertyFilterOperator;
+  tokenType?: PropertyFilterTokenType;
   match?: PropertyFilterOperatorMatch<TokenValue>;
   form?: PropertyFilterOperatorForm<TokenValue>;
   format?: PropertyFilterOperatorFormat<TokenValue>;
 }
 
+export type PropertyFilterTokenType = 'value' | 'enum';
+
 export type PropertyFilterOperatorMatch<TokenValue> =
   | PropertyFilterOperatorMatchByType
   | PropertyFilterOperatorMatchCustom<TokenValue>;
 
-export type PropertyFilterOperatorMatchByType = 'date' | 'datetime';
+export type PropertyFilterOperatorMatchByType = 'date' | 'datetime' | 'enum';
 
 export type PropertyFilterOperatorMatchCustom<TokenValue> = (itemValue: unknown, tokenValue: TokenValue) => boolean;
 
@@ -182,6 +185,7 @@ export interface PropertyFilterProperty<TokenValue = any> {
   defaultOperator?: PropertyFilterOperator;
   group?: string;
 }
+
 export interface PropertyFilterOption {
   propertyKey: string;
   value: string;

--- a/src/operations/property-filter.ts
+++ b/src/operations/property-filter.ts
@@ -8,40 +8,106 @@ import {
   UseCollectionOptions,
   PropertyFilterProperty,
   PropertyFilterTokenGroup,
+  PropertyFilterTokenType,
 } from '../interfaces';
 import { compareDates, compareTimestamps } from '../date-utils/compare-dates.js';
 import { Predicate } from './compose-filters';
 
 const filterUsingOperator = (
   itemValue: any,
-  tokenValue: any,
-  { operator, match }: PropertyFilterOperatorExtended<any>
+  {
+    tokenValue,
+    operator: { operator, match, tokenType },
+  }: {
+    tokenValue: any;
+    operator: PropertyFilterOperatorExtended<any>;
+  }
 ) => {
-  if (match === 'date' || match === 'datetime') {
-    const comparator = match === 'date' ? compareDates : compareTimestamps;
-    const comparisonResult = comparator(itemValue, tokenValue);
-    switch (operator) {
-      case '<':
-        return comparisonResult < 0;
-      case '<=':
-        return comparisonResult <= 0;
-      case '>':
-        return comparisonResult > 0;
-      case '>=':
-        return comparisonResult >= 0;
-      case '=':
-        return comparisonResult === 0;
-      case '!=':
-        return comparisonResult !== 0;
-      default:
-        return false;
-    }
-  } else if (typeof match === 'function') {
+  // For match="enum" we expect the value to be an array of values.
+  // The token can be an array, too (tokenType="enum") or a value (tokenType="value" or tokenType=undefined), examples:
+  // match(operator=":", token=["B", "A"], value=["A", "B", "C"]) == true
+  // match(operator=":", token="B", value=["A", "B", "C"]) == true
+  if (match === 'enum') {
+    return matchEnumValue({ tokenValue, itemValue, operator, tokenType });
+  }
+  // For match="date" or match="datetime" we expect the value to be a Date object.
+  // The token value is expected to be an ISO date- or datetime string, example:
+  // match(operator="=", token="2020-01-01", value=new Date("2020-01-01")) == true
+  else if (match === 'date' || match === 'datetime') {
+    return matchDateValue({ tokenValue, itemValue, operator, match });
+  }
+  // For custom match functions there is no expectation to value or token type: the function is supposed
+  // to handle everything. It is recommended to treat both the token and the value as unknowns.
+  else if (typeof match === 'function') {
     return match(itemValue, tokenValue);
   } else if (match) {
     throw new Error('Unsupported `operator.match` type given.');
   }
+  // For default matching logic we expect the value to be a primitive type or an object that matches by reference.
+  // The token can be an array (tokenType="enum") or a value (tokenType="value" or tokenType=undefined), examples:
+  // match(operator="=", token="A", value="A") == true
+  // match(operator="=", token=["A", "B"], value="A") == true
+  return matchPrimitiveValue({ tokenValue, itemValue, operator, tokenType });
+};
 
+function matchDateValue({
+  tokenValue,
+  itemValue,
+  operator,
+  match,
+}: {
+  tokenValue: any;
+  itemValue: any;
+  operator: PropertyFilterOperator;
+  match: 'date' | 'datetime';
+}) {
+  const comparator = match === 'date' ? compareDates : compareTimestamps;
+  const comparisonResult = comparator(itemValue, tokenValue);
+  switch (operator) {
+    case '<':
+      return comparisonResult < 0;
+    case '<=':
+      return comparisonResult <= 0;
+    case '>':
+      return comparisonResult > 0;
+    case '>=':
+      return comparisonResult >= 0;
+    case '=':
+      return comparisonResult === 0;
+    case '!=':
+      return comparisonResult !== 0;
+    default:
+      // Other operators are not supported.
+      return false;
+  }
+}
+
+function matchPrimitiveValue({
+  tokenValue,
+  itemValue,
+  operator,
+  tokenType,
+}: {
+  tokenValue: any;
+  itemValue: any;
+  operator: PropertyFilterOperator;
+  tokenType?: PropertyFilterTokenType;
+}): boolean {
+  if (tokenType === 'enum') {
+    if (!tokenValue || !Array.isArray(tokenValue)) {
+      // The token value must be an array when tokenType=="enum".
+      return false;
+    }
+    switch (operator) {
+      case '=':
+        return tokenValue && tokenValue.includes(itemValue);
+      case '!=':
+        return !tokenValue || !tokenValue.includes(itemValue);
+      default:
+        // Other operators are not supported.
+        return false;
+    }
+  }
   switch (operator) {
     case '<':
       return itemValue < tokenValue;
@@ -70,10 +136,88 @@ const filterUsingOperator = (
     default:
       throw new Error('Unsupported operator given.');
   }
-};
+}
+
+function matchEnumValue({
+  tokenValue,
+  itemValue,
+  operator,
+  tokenType,
+}: {
+  tokenValue: unknown;
+  itemValue: unknown;
+  operator: PropertyFilterOperator;
+  tokenType?: PropertyFilterTokenType;
+}): boolean {
+  const values = !itemValue ? [] : itemValue;
+  if (!Array.isArray(values)) {
+    // The items value must be an array or empty when match=="enum".
+    return false;
+  }
+
+  if (tokenType === 'enum') {
+    if (!tokenValue || !Array.isArray(tokenValue)) {
+      // The token value must be an array when tokenType=="enum".
+      return false;
+    }
+    switch (operator) {
+      case '=':
+        return checkArrayMatches(values, tokenValue);
+      case '!=':
+        return !checkArrayMatches(values, tokenValue);
+      case ':':
+        return checkArrayContains(values, tokenValue);
+      case '!:':
+        return !checkArrayContains(values, tokenValue);
+      default:
+        // Other operators are not supported.
+        return false;
+    }
+  }
+  switch (operator) {
+    case ':':
+      // eslint-disable-next-line eqeqeq
+      return values.length === 0 ? false : values.some(value => value == tokenValue);
+    case '!:':
+      // eslint-disable-next-line eqeqeq
+      return values.length === 0 ? true : values.every(value => value != tokenValue);
+    default:
+      // Other operators are not supported.
+      return false;
+  }
+}
+
+function checkArrayMatches(values: unknown[], token: unknown[]) {
+  if (values.length !== token.length) {
+    return false;
+  }
+  const valuesMap = values.reduce<Map<unknown, number>>(
+    (map, value) => map.set(value, (map.get(value) ?? 0) + 1),
+    new Map()
+  );
+  for (const tokenEntry of token) {
+    const count = valuesMap.get(tokenEntry);
+    if (count) {
+      count === 1 ? valuesMap.delete(tokenEntry) : valuesMap.set(tokenEntry, count - 1);
+    } else {
+      return false;
+    }
+  }
+  return valuesMap.size === 0;
+}
+
+function checkArrayContains(values: unknown[], token: unknown[]) {
+  const valuesSet = new Set(values);
+  for (const tokenEntry of token) {
+    if (!valuesSet.has(tokenEntry)) {
+      return false;
+    }
+  }
+  return true;
+}
 
 function freeTextFilter<T>(
-  value: string,
+  tokenValue: string,
   item: T,
   operator: PropertyFilterOperator,
   filteringPropertiesMap: FilteringPropertiesMap<T>
@@ -87,7 +231,7 @@ function freeTextFilter<T>(
     if (!propertyOperator) {
       return isNegation;
     }
-    return filterUsingOperator(item[propertyKey as keyof typeof item], value, propertyOperator);
+    return filterUsingOperator(item[propertyKey as keyof typeof item], { tokenValue, operator: propertyOperator });
   });
 }
 
@@ -100,12 +244,15 @@ function filterByToken<T>(token: PropertyFilterToken, item: T, filteringProperti
     ) {
       return false;
     }
-    const operator =
-      filteringPropertiesMap[token.propertyKey as keyof FilteringPropertiesMap<T>].operators[token.operator];
+    const property = filteringPropertiesMap[token.propertyKey as keyof FilteringPropertiesMap<T>];
+    const operator = property.operators[token.operator];
     const itemValue: any = operator?.match
       ? item[token.propertyKey as keyof T]
       : fixupFalsyValues(item[token.propertyKey as keyof T]);
-    return filterUsingOperator(itemValue, token.value, operator ?? { operator: token.operator });
+    return filterUsingOperator(itemValue, {
+      tokenValue: token.value,
+      operator: operator ?? { operator: token.operator },
+    });
   }
   return freeTextFilter(token.value, item, token.operator, filteringPropertiesMap);
 }
@@ -154,12 +301,10 @@ export function createPropertyFilterPredicate<T>(
         if (typeof op === 'string') {
           operatorMap[op] = { operator: op };
         } else {
-          operatorMap[op.operator] = { operator: op.operator, match: op.match };
+          operatorMap[op.operator] = { operator: op.operator, match: op.match, tokenType: op.tokenType };
         }
       });
-      acc[key as keyof T] = {
-        operators: operatorMap,
-      };
+      acc[key as keyof T] = { operators: operatorMap };
       return acc;
     },
     {} as FilteringPropertiesMap<T>


### PR DESCRIPTION
A POC implementing enum props support for many-to-one and many-to-many searches.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
