### PR TITLE
fix: Ensure that auto-filtering only matches primitive values

### DIFF
--- a/src/__tests__/operations/filter.test.ts
+++ b/src/__tests__/operations/filter.test.ts
@@ -142,4 +142,39 @@ describe('with filteringFunction', () => {
     expect(filteringSpy).toHaveBeenCalledTimes(3);
     expect(filteringSpy).toHaveBeenCalledWith(expect.any(Object), '', undefined);
   });
+
+  test('does not match object values', () => {
+    const items = [
+      { id: 1, field: {} },
+      { id: 2, field: 'object' },
+      { id: 3, field: [{}, {}] },
+      { id: 4, field: 'Some text containing [object Object]' },
+    ];
+    const { items: processed } = processItems(
+      items,
+      { filteringText: 'object' },
+      {
+        filtering: {},
+      }
+    );
+    expect(processed).toHaveLength(2);
+    expect(processed[0]?.id).toEqual(2);
+    expect(processed[1]?.id).toEqual(4);
+  });
+
+  test('does not match against date objects', () => {
+    const items = [
+      { id: 1, field: new Date('2024-12-01') },
+      { id: 2, field: '2024-12-01' },
+    ];
+    const { items: processed } = processItems(
+      items,
+      { filteringText: '2024' },
+      {
+        filtering: {},
+      }
+    );
+    expect(processed).toHaveLength(1);
+    expect(processed[0]?.id).toEqual(2);
+  });
 });

--- a/src/operations/filter.ts
+++ b/src/operations/filter.ts
@@ -10,12 +10,13 @@ function defaultFilteringFunction<T>(item: T, filteringText: string, filteringFi
   filteringFields = filteringFields || Object.keys(item as Record<string, any>);
   const lowFilteringText = filteringText.toLowerCase();
 
-  return filteringFields.some(
-    key =>
-      String((item as Record<string, any>)[key])
-        .toLowerCase()
-        .indexOf(lowFilteringText) > -1
-  );
+  return filteringFields.some(key => {
+    const value = (item as Record<string, any>)[key];
+    if (value && typeof value === 'object') {
+      return false;
+    }
+    return String(value).toLowerCase().indexOf(lowFilteringText) > -1;
+  });
 }
 
 export function createFilterPredicate<T>(


### PR DESCRIPTION
*Issue #, if available:* AWSUI-60174, AWSUI-19651

*Description of changes:*

Update so that auto-filtering only uses primitive values, to avoid e.g. "object" matching {}, or stringified date object being matched by timezone name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
