### PR TITLE
feat: Support React 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "vitest": "^1.6.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "NOTICE"
   ],
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@testing-library/react": "^11.2.7",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -95,7 +95,7 @@ interface UseCollectionResultBase<T> {
       onExpandableItemToggle(event: CustomEventLike<{ item: T; expanded: boolean }>): void;
     };
     trackBy?: string | ((item: T) => string);
-    ref: React.RefObject<CollectionRef>;
+    ref: React.RefObject<CollectionRef | null>;
     totalItemsCount: number;
     firstIndex: number;
   };

--- a/src/use-collection-state.ts
+++ b/src/use-collection-state.ts
@@ -1,14 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { useReducer } from 'react';
-import { createActions, collectionReducer, CollectionReducer } from './utils.js';
+import { createActions, collectionReducer } from './utils.js';
 import { UseCollectionOptions, CollectionState, CollectionRef, CollectionActions } from './interfaces';
 
 export function useCollectionState<T>(
   options: UseCollectionOptions<T>,
-  collectionRef: React.RefObject<CollectionRef>
+  collectionRef: React.RefObject<CollectionRef | null>
 ): readonly [CollectionState<T>, CollectionActions<T>] {
-  const [state, dispatch] = useReducer<CollectionReducer<T>>(collectionReducer, {
+  const [state, dispatch] = useReducer(collectionReducer<T>, {
     selectedItems: options.selection?.defaultSelectedItems ?? [],
     expandedItems: options.expandableRows?.defaultExpandedItems ?? [],
     sortingState: options.sorting?.defaultState,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Dispatch, Reducer, ReactNode } from 'react';
+import { Dispatch, ReactNode } from 'react';
 import {
   UseCollectionOptions,
   CollectionState,
@@ -45,7 +45,7 @@ type Action<T> =
   | PaginationAction
   | FilteringAction
   | PropertyFilteringAction;
-export type CollectionReducer<T> = Reducer<CollectionState<T>, Action<T>>;
+
 export function collectionReducer<T>(state: CollectionState<T>, action: Action<T>): CollectionState<T> {
   const newState = { ...state };
   switch (action.type) {
@@ -79,27 +79,27 @@ export function createActions<T>({
   collectionRef,
 }: {
   dispatch: Dispatch<Action<T>>;
-  collectionRef: React.RefObject<CollectionRef>;
+  collectionRef: React.RefObject<CollectionRef | null>;
 }): CollectionActions<T> {
   return {
     setFiltering(filteringText) {
       dispatch({ type: 'filtering', filteringText });
-      collectionRef.current && collectionRef.current.scrollToTop();
+      collectionRef.current?.scrollToTop();
     },
     setSorting(state: SortingState<T>) {
       dispatch({ type: 'sorting', sortingState: state });
-      collectionRef.current && collectionRef.current.scrollToTop();
+      collectionRef.current?.scrollToTop();
     },
     setCurrentPage(pageIndex: number) {
       dispatch({ type: 'pagination', pageIndex });
-      collectionRef.current && collectionRef.current.scrollToTop();
+      collectionRef.current?.scrollToTop();
     },
     setSelectedItems(selectedItems: Array<T>) {
       dispatch({ type: 'selection', selectedItems });
     },
     setPropertyFiltering(query: PropertyFilterQuery) {
       dispatch({ type: 'property-filtering', query });
-      collectionRef.current && collectionRef.current.scrollToTop();
+      collectionRef.current?.scrollToTop();
     },
     setExpandedItems(expandedItems: ReadonlyArray<T>) {
       dispatch({ type: 'expansion', expandedItems });
@@ -118,7 +118,7 @@ export function createSyncProps<T>(
     propertyFilteringQuery,
   }: CollectionState<T>,
   actions: CollectionActions<T>,
-  collectionRef: React.RefObject<CollectionRef>,
+  collectionRef: React.RefObject<CollectionRef | null>,
   {
     pagesCount,
     actualPageIndex,


### PR DESCRIPTION
*Issue #, if available:* AWSUI-60250

*Description of changes:*

Adds React 19 as a supported peer dependency. Tested locally by updating `react` and `@types/react` to 19.0.0 and seeing if it complains about anything (see next paragraph). The two considerations of note were:
1. [Removal of non-mutable refs](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#useref-requires-argument). For us, this means that `React.RefObject<T>` goes from `{ readonly current: T | null }` to `{ current: T }`, which means we need to include the `null` alternative ourselves. Adding a `| null` here should be backwards compatible, but this is a change to the interfaces that needs to be called out.
2. [Improved `useReducer` typings](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#useref-requires-argument). React's migration guidelines of "not to pass type arguments to useReducer" is correct, but I had to make some small changes to make sure this also worked in earlier versions.

We've gotta have a talk about the growing number of React version permutations we somehow have to test against. Currently, this added support is untested (outside of my local testing before I made this PR). Should we have some kind of script to rerun unit tests against different versions of React? I don't feel so confident about a single test suite (in any of our packages) covering *four* major versions over *five* years of React releases.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
