### PR TITLE
fix: Remove condition clamping pageIndex

### DIFF
--- a/src/__tests__/operations/paginate.test.ts
+++ b/src/__tests__/operations/paginate.test.ts
@@ -17,23 +17,12 @@ test('default pagination', () => {
 test('should reset the currentPageIndex to 1 when out of range', () => {
   const items = generateItems(25);
 
-  // Page number is above the maximum
+  // Page number is below the minimum
   let {
     items: processed,
     pagesCount,
     actualPageIndex,
-  } = processItems(items, { currentPageIndex: 4 }, { pagination: {} });
-  expect(actualPageIndex).toEqual(1);
-  expect(pagesCount).toEqual(3);
-  expect(processed).toHaveLength(10);
-  expect(processed[0]).toEqual(items[0]);
-
-  // Page number is below the minimum
-  ({
-    items: processed,
-    pagesCount,
-    actualPageIndex,
-  } = processItems(items, { currentPageIndex: 0 }, { pagination: {} }));
+  } = processItems(items, { currentPageIndex: 0 }, { pagination: {} });
   expect(actualPageIndex).toEqual(1);
   expect(pagesCount).toEqual(3);
   expect(processed).toHaveLength(10);

--- a/src/__tests__/operations/paginate.test.ts
+++ b/src/__tests__/operations/paginate.test.ts
@@ -87,6 +87,18 @@ test('displays the last page when the number of items is divisible by page size'
   expect(processed[9]).toEqual(items[19]);
 });
 
+test('displays an out of range page', () => {
+  const items = generateItems(20);
+  const {
+    items: processed,
+    pagesCount,
+    actualPageIndex,
+  } = processItems(items, { currentPageIndex: 3 }, { pagination: {} });
+  expect(actualPageIndex).toEqual(3);
+  expect(pagesCount).toEqual(2);
+  expect(processed).toHaveLength(0);
+});
+
 test('supports custom page size', () => {
   const items = generateItems(35);
   const { items: processed, pagesCount } = processItems(

--- a/src/__tests__/stubs.tsx
+++ b/src/__tests__/stubs.tsx
@@ -81,7 +81,9 @@ const Table = React.forwardRef<CollectionRef, TableProps>(
     ref: React.Ref<CollectionRef>
   ) => {
     const scrollToTop = () => {
-      spy && spy();
+      if (spy) {
+        spy();
+      }
     };
     React.useImperativeHandle(ref, () => ({
       scrollToTop,
@@ -245,7 +247,11 @@ function Pagination({
   return (
     <ul>
       <li>
-        <button data-testid="previous-page" disabled={disabled} onClick={() => changePage(currentPageIndex - 1)}>
+        <button
+          data-testid="previous-page"
+          disabled={disabled || currentPageIndex === 1}
+          onClick={() => changePage(currentPageIndex - 1)}
+        >
           &lt;
         </button>
       </li>
@@ -258,7 +264,11 @@ function Pagination({
         <span data-testid="pages-count">{pagesCount}</span>
       </li>
       <li>
-        <button data-testid="next-page" disabled={disabled} onClick={() => changePage(currentPageIndex + 1)}>
+        <button
+          data-testid="next-page"
+          disabled={disabled || currentPageIndex === pagesCount}
+          onClick={() => changePage(currentPageIndex + 1)}
+        >
           &gt;
         </button>
       </li>

--- a/src/__tests__/use-collection.test.tsx
+++ b/src/__tests__/use-collection.test.tsx
@@ -165,8 +165,8 @@ test('should prevent pagination from going out of bounds', () => {
   expect(getCurrentPage()).toEqual('2');
   expect(getVisibleItems()[0]).toEqual('11');
   fireEvent.click(findNextPage());
-  expect(getCurrentPage()).toEqual('1');
-  expect(getVisibleItems()[0]).toEqual('1');
+  expect(getCurrentPage()).toEqual('2');
+  expect(getVisibleItems()[0]).toEqual('11');
 });
 
 test('should evoke scrollToTop from the ref on pagination, filtering, property filtering and sorting', () => {

--- a/src/operations/pagination.ts
+++ b/src/operations/pagination.ts
@@ -16,7 +16,7 @@ export function createPageProps<T>(
   const pageSize = pagination.pageSize ?? DEFAULT_PAGE_SIZE;
   const pagesCount = Math.ceil(items.length / pageSize);
   let pageIndex = currentPageIndex ?? 1;
-  if (pageIndex < 1 || pageIndex > pagesCount || Number.isNaN(pageIndex)) {
+  if (pageIndex < 1 || Number.isNaN(pageIndex)) {
     pageIndex = 1;
   }
   return { pageSize, pagesCount, pageIndex };


### PR DESCRIPTION
Remove logic that resets current page index to 1 if a value greater than the total available number of pages is passed in. Why? This logic causes problems when trying to load subsequent pages of data from a paginated (but not filter-/sort-enabled) API.

*Issue #, if available:* Xw9JA4nAmlRd

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
