### PR TITLE
fix: Hide new pageIndex logic behind flag

### DIFF
--- a/src/__tests__/operations/paginate.test.ts
+++ b/src/__tests__/operations/paginate.test.ts
@@ -93,7 +93,7 @@ test('displays an out of range page', () => {
     items: processed,
     pagesCount,
     actualPageIndex,
-  } = processItems(items, { currentPageIndex: 3 }, { pagination: {} });
+  } = processItems(items, { currentPageIndex: 3 }, { pagination: { allowPageOutOfRange: true } });
   expect(actualPageIndex).toEqual(3);
   expect(pagesCount).toEqual(2);
   expect(processed).toHaveLength(0);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -44,7 +44,7 @@ export interface UseCollectionOptions<T> {
     freeTextFiltering?: PropertyFilterFreeTextFiltering;
   };
   sorting?: { defaultState?: SortingState<T> };
-  pagination?: { defaultPage?: number; pageSize?: number };
+  pagination?: { defaultPage?: number; pageSize?: number; allowPageOutOfRange?: boolean };
   selection?: {
     defaultSelectedItems?: ReadonlyArray<T>;
     keepSelection?: boolean;

--- a/src/operations/pagination.ts
+++ b/src/operations/pagination.ts
@@ -16,7 +16,7 @@ export function createPageProps<T>(
   const pageSize = pagination.pageSize ?? DEFAULT_PAGE_SIZE;
   const pagesCount = Math.ceil(items.length / pageSize);
   let pageIndex = currentPageIndex ?? 1;
-  if (pageIndex < 1 || Number.isNaN(pageIndex)) {
+  if (pageIndex < 1 || (pageIndex > pagesCount && !pagination.allowPageOutOfRange) || Number.isNaN(pageIndex)) {
     pageIndex = 1;
   }
   return { pageSize, pagesCount, pageIndex };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Revision of #99 so that the new logic is behind a flag, as the change turned out to be breaking for some customers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
