### PR TITLE
feat: memoize filtering internals; add freeTextFilterable and dropdownFilterable flags

### DIFF
--- a/src/__tests__/operations/property-filter.test.ts
+++ b/src/__tests__/operations/property-filter.test.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { test, expect, describe, vi } from 'vitest';
 import { processItems } from '../../operations';
-import { PropertyFilterOperator } from '../../interfaces';
+import { makeFilteringPropertiesMap } from '../../operations/property-filter.js';
+import { PropertyFilterOperator, PropertyFilterProperty } from '../../interfaces';
 import * as logging from '../../logging';
 
 const propertyFiltering = {
@@ -888,3 +889,122 @@ describe('Token groups', () => {
     ]);
   });
 });
+
+describe('makeFilteringPropertiesMap', () => {
+  const props: readonly PropertyFilterProperty[] = [
+    { key: 'id', propertyLabel: 'ID', groupValuesLabel: '', operators: [':', '=', '!='] },
+    { key: 'name', propertyLabel: 'Name', groupValuesLabel: '', operators: [':', '=', '!='] },
+  ];
+
+  test('builds a map keyed by property key', () => {
+    const map = makeFilteringPropertiesMap(props);
+    expect('id' in map).toBe(true);
+    expect('name' in map).toBe(true);
+  });
+
+  test('operators are indexed by operator string', () => {
+    const map = makeFilteringPropertiesMap(props);
+    expect((map as any).id.operators[':']).toBeDefined();
+    expect((map as any).id.operators['=']).toBeDefined();
+    expect((map as any).id.operators['!=']).toBeDefined();
+  });
+
+  test('freeTextFilterable defaults to true', () => {
+    const map = makeFilteringPropertiesMap(props);
+    expect((map as any).id.freeTextFilterable).toBe(true);
+  });
+
+  test('freeTextFilterable:false is stored in map', () => {
+    const map = makeFilteringPropertiesMap([
+      { key: 'tag', propertyLabel: '', groupValuesLabel: '', operators: ['='], freeTextFilterable: false },
+    ]);
+    expect((map as any).tag.freeTextFilterable).toBe(false);
+  });
+
+  test('dropdownFilterable defaults to true', () => {
+    const map = makeFilteringPropertiesMap(props);
+    expect((map as any).id.dropdownFilterable).toBe(true);
+  });
+
+  test('dropdownFilterable:false is stored in map', () => {
+    const map = makeFilteringPropertiesMap([
+      { key: 'val', propertyLabel: '', groupValuesLabel: '', operators: ['='], dropdownFilterable: false },
+    ]);
+    expect((map as any).val.dropdownFilterable).toBe(false);
+  });
+
+  test('same input produces structurally equal output', () => {
+    expect(makeFilteringPropertiesMap(props)).toEqual(makeFilteringPropertiesMap(props));
+  });
+});
+
+describe('freeTextFilterable flag', () => {
+  const baseProps: readonly PropertyFilterProperty[] = [
+    { key: 'name', propertyLabel: 'Name', groupValuesLabel: '', operators: [':', '='] },
+  ];
+  const items = [
+    { name: 'alpha', tag: 'prod' },
+    { name: 'beta', tag: 'prod' },
+  ];
+
+  test('freeTextFilterable:false excludes column from free-text search', () => {
+    const { items: result } = processItems(
+      items,
+      { propertyFilteringQuery: { tokens: [{ operator: ':', value: 'prod' }], operation: 'and' } },
+      {
+        propertyFiltering: {
+          filteringProperties: [
+            ...baseProps,
+            {
+              key: 'tag',
+              propertyLabel: 'Tag',
+              groupValuesLabel: '',
+              operators: [':', '='],
+              freeTextFilterable: false,
+            },
+          ],
+        },
+      }
+    );
+    expect(result).toEqual([]);
+  });
+
+  test('freeTextFilterable:false does not affect property-specific tokens', () => {
+    const { items: result } = processItems(
+      items,
+      { propertyFilteringQuery: { tokens: [{ propertyKey: 'tag', operator: '=', value: 'prod' }], operation: 'and' } },
+      {
+        propertyFiltering: {
+          filteringProperties: [
+            ...baseProps,
+            {
+              key: 'tag',
+              propertyLabel: 'Tag',
+              groupValuesLabel: '',
+              operators: [':', '='],
+              freeTextFilterable: false,
+            },
+          ],
+        },
+      }
+    );
+    expect(result).toEqual(items);
+  });
+
+  test('without freeTextFilterable:false, free-text searches all columns', () => {
+    const { items: result } = processItems(
+      items,
+      { propertyFilteringQuery: { tokens: [{ operator: ':', value: 'prod' }], operation: 'and' } },
+      {
+        propertyFiltering: {
+          filteringProperties: [
+            ...baseProps,
+            { key: 'tag', propertyLabel: 'Tag', groupValuesLabel: '', operators: [':', '='] },
+          ],
+        },
+      }
+    );
+    expect(result).toEqual(items);
+  });
+});
+

--- a/src/__tests__/use-collection.test.tsx
+++ b/src/__tests__/use-collection.test.tsx
@@ -1,9 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { test, expect, describe, vi } from 'vitest';
-import { fireEvent, render as testRender } from '@testing-library/react';
+import { fireEvent, render as testRender, act } from '@testing-library/react';
 import * as React from 'react';
 import { useCollection } from '../';
+import { computeFilteringOptions } from '../utils.js';
 import { PropertyFilterProperty } from '../interfaces';
 import { Demo, Item, render } from './stubs';
 
@@ -587,5 +588,102 @@ describe('total items count and page range', () => {
     const { getRowIndices, getTotalItemsCount } = render(<App />);
     expect(getRowIndices()).toEqual(['1', '2', '3', '4']);
     expect(getTotalItemsCount()).toEqual('4');
+  });
+});
+
+describe('computeFilteringOptions', () => {
+  const PROPS: readonly PropertyFilterProperty[] = [
+    { key: 'id', propertyLabel: 'ID', groupValuesLabel: 'ID values', operators: [':', '=', '!='] },
+    { key: 'name', propertyLabel: 'Name', groupValuesLabel: 'Name values', operators: [':', '=', '!='] },
+  ];
+
+  test('returns empty array when filteringProperties is undefined', () => {
+    expect(computeFilteringOptions([], undefined)).toEqual([]);
+  });
+
+  test('returns empty array when filteringProperties is empty', () => {
+    expect(computeFilteringOptions([{ id: 'a' }], [])).toEqual([]);
+  });
+
+  test('generates one option per unique non-empty value per property', () => {
+    const items = [
+      { id: 'a', name: 'alpha' },
+      { id: 'b', name: 'alpha' },
+      { id: 'c', name: 'beta' },
+    ];
+    const result = computeFilteringOptions(items, PROPS);
+    expect(result).toEqual([
+      { propertyKey: 'id', value: 'a' },
+      { propertyKey: 'id', value: 'b' },
+      { propertyKey: 'id', value: 'c' },
+      { propertyKey: 'name', value: 'alpha' },
+      { propertyKey: 'name', value: 'beta' },
+    ]);
+  });
+
+  test('skips falsy values', () => {
+    const items = [
+      { id: 'a', name: undefined },
+      { id: 'b', name: null as any },
+    ];
+    expect(computeFilteringOptions(items, PROPS).filter(o => o.propertyKey === 'name')).toEqual([]);
+  });
+
+  test('skips freeTextFilterable:false and dropdownFilterable:false columns', () => {
+    const props: readonly PropertyFilterProperty[] = [
+      ...PROPS,
+      { key: 'tag', propertyLabel: 'Tag', groupValuesLabel: '', operators: ['='], freeTextFilterable: false },
+      { key: 'val', propertyLabel: 'Val', groupValuesLabel: '', operators: ['='], dropdownFilterable: false },
+    ];
+    const items = [{ id: 'a', name: 'x', tag: 'skip', val: 'skip' }];
+    const result = computeFilteringOptions(items, props);
+    expect(result.some(o => o.propertyKey === 'tag')).toBe(false);
+    expect(result.some(o => o.propertyKey === 'val')).toBe(false);
+    expect(result.some(o => o.propertyKey === 'id')).toBe(true);
+  });
+});
+
+describe('filteringOptions stability in useCollection', () => {
+  const STABLE_PROPS: readonly PropertyFilterProperty[] = [
+    { key: 'id', propertyLabel: 'ID', groupValuesLabel: '', operators: ['='] },
+  ];
+
+  test('filteringOptions reference is stable when allItems and filteringProperties are unchanged', () => {
+    const items = [{ id: 'a' }];
+    const snapshots: (readonly { propertyKey: string; value: string }[])[] = [];
+    function App({ tick }: { tick: number }) {
+      const result = useCollection(items, {
+        propertyFiltering: { filteringProperties: STABLE_PROPS },
+        pagination: { pageSize: tick > 0 ? 10 : 5 },
+      });
+      snapshots.push(result.propertyFilterProps.filteringOptions);
+      return null;
+    }
+    const { rerender } = testRender(<App tick={1} />);
+    act(() => {
+      rerender(<App tick={2} />);
+    });
+    act(() => {
+      rerender(<App tick={3} />);
+    });
+    expect(snapshots[0]).toBe(snapshots[1]);
+    expect(snapshots[1]).toBe(snapshots[2]);
+  });
+
+  test('filteringOptions update when allItems change', () => {
+    const items1 = [{ id: 'a' }];
+    const items2 = [{ id: 'a' }, { id: 'b' }];
+    const snapshots: (readonly { propertyKey: string; value: string }[])[] = [];
+    function App({ items }: { items: typeof items1 }) {
+      const result = useCollection(items, { propertyFiltering: { filteringProperties: STABLE_PROPS } });
+      snapshots.push(result.propertyFilterProps.filteringOptions);
+      return null;
+    }
+    const { rerender } = testRender(<App items={items1} />);
+    act(() => {
+      rerender(<App items={items2} />);
+    });
+    expect(snapshots[0]).not.toBe(snapshots[1]);
+    expect(snapshots[1].some(o => o.value === 'b')).toBe(true);
   });
 });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -218,6 +218,8 @@ export interface PropertyFilterProperty<TokenValue = any> {
   operators?: readonly (PropertyFilterOperator | PropertyFilterOperatorExtended<TokenValue>)[];
   defaultOperator?: PropertyFilterOperator;
   group?: string;
+  freeTextFilterable?: false;
+  dropdownFilterable?: false;
 }
 
 export interface PropertyFilterOption {

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,8 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { UseCollectionOptions, CollectionState, TrackBy, ExpandableRowsResultBase } from '../interfaces';
+import {
+  UseCollectionOptions,
+  CollectionState,
+  TrackBy,
+  ExpandableRowsResultBase,
+  PropertyFilterQuery,
+} from '../interfaces';
 import { createFilterPredicate } from './filter.js';
-import { createPropertyFilterPredicate } from './property-filter.js';
+import { createPropertyFilterPredicate, FilteringPropertiesMap } from './property-filter.js';
 import { createComparator } from './sort.js';
 import { createPageProps } from './pagination.js';
 import { composeFilters } from './compose-filters.js';
@@ -12,7 +18,10 @@ import { computeFlatItems, computeTreeItems } from './items-tree.js';
 export function processItems<T>(
   allItems: ReadonlyArray<T>,
   state: Partial<CollectionState<T>>,
-  { filtering, sorting, pagination, propertyFiltering, expandableRows, selection }: UseCollectionOptions<T>
+  { filtering, sorting, pagination, propertyFiltering, expandableRows, selection }: UseCollectionOptions<T>,
+  filteringPropertiesMap?: FilteringPropertiesMap<T>,
+  prebuiltFilteringFunction?: (item: T, query: PropertyFilterQuery) => boolean,
+  propertyFilterPredicate?: ((item: T) => boolean) | null
 ): {
   items: readonly T[];
   allPageItems: readonly T[];
@@ -23,10 +32,19 @@ export function processItems<T>(
   selectedItems: undefined | T[];
   expandableRows?: ExpandableRowsResultBase<T>;
 } {
-  const filterPredicate = composeFilters(
-    createPropertyFilterPredicate(propertyFiltering, state.propertyFilteringQuery),
-    createFilterPredicate(filtering, state.filteringText)
-  );
+  const textFilterPredicate = createFilterPredicate(filtering, state.filteringText);
+  const resolvedPropertyPredicate =
+    propertyFilterPredicate !== undefined
+      ? propertyFilterPredicate
+      : createPropertyFilterPredicate(
+          propertyFiltering,
+          state.propertyFilteringQuery,
+          filteringPropertiesMap,
+          prebuiltFilteringFunction
+        );
+  const filterPredicate = textFilterPredicate
+    ? composeFilters(resolvedPropertyPredicate, textFilterPredicate)
+    : resolvedPropertyPredicate;
   const sortingComparator = createComparator(sorting, state.sortingState);
   const { items, rootItemsCount, selectableItemsCount, getItemChildren, isItemExpandable, getItemsCount } =
     expandableRows

--- a/src/operations/property-filter.ts
+++ b/src/operations/property-filter.ts
@@ -136,14 +136,15 @@ function freeTextFilter<T>(
   tokenValue: string,
   item: T,
   operator: PropertyFilterOperator,
+  columnKeys: string[],
   filteringPropertiesMap: FilteringPropertiesMap<T>
 ): boolean {
   // If the operator is not a negation, we just need one property of the object to match.
   // If the operator is a negation, we want none of the properties of the object to match.
   const isNegation = operator.startsWith('!');
-  return Object.keys(filteringPropertiesMap)[isNegation ? 'every' : 'some'](propertyKey => {
-    const { operators } = filteringPropertiesMap[propertyKey as keyof typeof filteringPropertiesMap];
-    const propertyOperator = operators[operator];
+  return columnKeys[isNegation ? 'every' : 'some'](propertyKey => {
+    const entry = filteringPropertiesMap[propertyKey as keyof typeof filteringPropertiesMap];
+    const propertyOperator = entry.operators[operator];
     if (!propertyOperator) {
       return isNegation;
     }
@@ -151,7 +152,12 @@ function freeTextFilter<T>(
   });
 }
 
-function filterByToken<T>(token: PropertyFilterToken, item: T, filteringPropertiesMap: FilteringPropertiesMap<T>) {
+function filterByToken<T>(
+  token: PropertyFilterToken,
+  item: T,
+  filteringPropertiesMap: FilteringPropertiesMap<T>,
+  columnKeys: string[]
+) {
   if (token.propertyKey) {
     // token refers to a unknown property or uses an unsupported operator
     if (
@@ -170,7 +176,7 @@ function filterByToken<T>(token: PropertyFilterToken, item: T, filteringProperti
       operator: operator ?? { operator: token.operator },
     });
   }
-  return freeTextFilter(token.value, item, token.operator, filteringPropertiesMap);
+  return freeTextFilter(token.value, item, token.operator, columnKeys, filteringPropertiesMap);
 }
 
 function isPropertyFilterTokenGroup(t: PropertyFilterToken | PropertyFilterTokenGroup): t is PropertyFilterTokenGroup {
@@ -178,29 +184,42 @@ function isPropertyFilterTokenGroup(t: PropertyFilterToken | PropertyFilterToken
   return key in t;
 }
 
-function defaultFilteringFunction<T>(filteringPropertiesMap: FilteringPropertiesMap<T>) {
-  return (item: T, query: PropertyFilterQuery) => {
-    function evaluate(tokenOrGroup: PropertyFilterToken | PropertyFilterTokenGroup): boolean {
-      if (isPropertyFilterTokenGroup(tokenOrGroup)) {
-        let result = tokenOrGroup.operation === 'and' ? true : !tokenOrGroup.tokens.length;
-        for (const group of tokenOrGroup.tokens) {
-          result = tokenOrGroup.operation === 'and' ? result && evaluate(group) : result || evaluate(group);
-        }
-        return result;
-      } else {
-        return filterByToken(tokenOrGroup, item, filteringPropertiesMap);
-      }
+function evaluate<T>(
+  tokenOrGroup: PropertyFilterToken | PropertyFilterTokenGroup,
+  item: T,
+  filteringPropertiesMap: FilteringPropertiesMap<T>,
+  columnKeys: string[]
+): boolean {
+  if (isPropertyFilterTokenGroup(tokenOrGroup)) {
+    let result = tokenOrGroup.operation === 'and' ? true : !tokenOrGroup.tokens.length;
+    for (const group of tokenOrGroup.tokens) {
+      result =
+        tokenOrGroup.operation === 'and'
+          ? result && evaluate(group, item, filteringPropertiesMap, columnKeys)
+          : result || evaluate(group, item, filteringPropertiesMap, columnKeys);
     }
-    return evaluate({
-      operation: query.operation,
-      tokens: query.tokenGroups ?? query.tokens,
-    });
+    return result;
+  } else {
+    return filterByToken(tokenOrGroup, item, filteringPropertiesMap, columnKeys);
+  }
+}
+
+function defaultFilteringFunction<T>(filteringPropertiesMap: FilteringPropertiesMap<T>, columnKeys: string[]) {
+  return (item: T, query: PropertyFilterQuery) => {
+    return evaluate(
+      { operation: query.operation, tokens: query.tokenGroups ?? query.tokens },
+      item,
+      filteringPropertiesMap,
+      columnKeys
+    );
   };
 }
 
-type FilteringPropertiesMap<T> = {
+export type FilteringPropertiesMap<T> = {
   [key in keyof T]: {
     operators: FilteringOperatorsMap;
+    freeTextFilterable: boolean;
+    dropdownFilterable: boolean;
   };
 };
 
@@ -208,15 +227,11 @@ type FilteringOperatorsMap = {
   [key in PropertyFilterOperator]?: PropertyFilterOperatorExtended<any>;
 };
 
-export function createPropertyFilterPredicate<T>(
-  propertyFiltering: UseCollectionOptions<T>['propertyFiltering'],
-  query: PropertyFilterQuery = { tokens: [], operation: 'and' }
-): null | Predicate<T> {
-  if (!propertyFiltering) {
-    return null;
-  }
-  const filteringPropertiesMap = propertyFiltering.filteringProperties.reduce<FilteringPropertiesMap<T>>(
-    (acc: FilteringPropertiesMap<T>, { key, operators, defaultOperator }: PropertyFilterProperty) => {
+export function makeFilteringPropertiesMap<T>(
+  filteringProperties: readonly PropertyFilterProperty[]
+): FilteringPropertiesMap<T> {
+  return filteringProperties.reduce<FilteringPropertiesMap<T>>(
+    (acc, { key, operators, defaultOperator, freeTextFilterable, dropdownFilterable }: PropertyFilterProperty) => {
       const operatorMap: FilteringOperatorsMap = { [defaultOperator ?? '=']: { operator: defaultOperator ?? '=' } };
       operators?.forEach(op => {
         if (typeof op === 'string') {
@@ -225,12 +240,38 @@ export function createPropertyFilterPredicate<T>(
           operatorMap[op.operator] = { operator: op.operator, match: op.match, tokenType: op.tokenType };
         }
       });
-      acc[key as keyof T] = { operators: operatorMap };
+      acc[key as keyof T] = {
+        operators: operatorMap,
+        freeTextFilterable: freeTextFilterable !== false,
+        dropdownFilterable: dropdownFilterable !== false,
+      };
       return acc;
     },
     {} as FilteringPropertiesMap<T>
   );
-  const filteringFunction = propertyFiltering.filteringFunction || defaultFilteringFunction(filteringPropertiesMap);
+}
+
+export function makeDefaultFilteringFunction<T>(
+  filteringPropertiesMap: FilteringPropertiesMap<T>
+): (item: T, query: PropertyFilterQuery) => boolean {
+  const columnKeys = Object.keys(filteringPropertiesMap).filter(
+    k => (filteringPropertiesMap as any)[k].freeTextFilterable !== false
+  );
+  return defaultFilteringFunction(filteringPropertiesMap, columnKeys);
+}
+
+export function createPropertyFilterPredicate<T>(
+  propertyFiltering: UseCollectionOptions<T>['propertyFiltering'],
+  query: PropertyFilterQuery = { tokens: [], operation: 'and' },
+  filteringPropertiesMap?: FilteringPropertiesMap<T>,
+  prebuiltFilteringFunction?: (item: T, query: PropertyFilterQuery) => boolean
+): null | Predicate<T> {
+  if (!propertyFiltering) {
+    return null;
+  }
+  const map = filteringPropertiesMap ?? makeFilteringPropertiesMap<T>(propertyFiltering.filteringProperties);
+  const filteringFunction =
+    propertyFiltering.filteringFunction || prebuiltFilteringFunction || makeDefaultFilteringFunction(map);
   return item => filteringFunction(item, query);
 }
 

--- a/src/use-collection.ts
+++ b/src/use-collection.ts
@@ -1,14 +1,33 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { useRef } from 'react';
+import { useRef, useMemo } from 'react';
 import { processItems, processSelectedItems, itemsAreEqual } from './operations/index.js';
+import { makeFilteringPropertiesMap, makeDefaultFilteringFunction } from './operations/property-filter.js';
 import { UseCollectionOptions, UseCollectionResult, CollectionRef } from './interfaces';
-import { createSyncProps } from './utils.js';
+import { createSyncProps, computeFilteringOptions } from './utils.js';
 import { useCollectionState } from './use-collection-state.js';
 
 export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollectionOptions<T>): UseCollectionResult<T> {
   const collectionRef = useRef<CollectionRef>(null);
   const [state, actions] = useCollectionState(options, collectionRef);
+
+  const filteringProperties = options.propertyFiltering?.filteringProperties;
+
+  const filteringPropertiesMap = useMemo(
+    () => (filteringProperties ? makeFilteringPropertiesMap<T>(filteringProperties) : undefined),
+    [filteringProperties]
+  );
+
+  const defaultFilteringFunction = useMemo(
+    () => (filteringPropertiesMap ? makeDefaultFilteringFunction<T>(filteringPropertiesMap) : undefined),
+    [filteringPropertiesMap]
+  );
+
+  const propertyFilterPredicate = useMemo(
+    () => (defaultFilteringFunction ? (item: T) => defaultFilteringFunction(item, state.propertyFilteringQuery) : null),
+    [defaultFilteringFunction, state.propertyFilteringQuery]
+  );
+
   const {
     items,
     allPageItems,
@@ -18,7 +37,7 @@ export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollect
     actualPageIndex,
     selectedItems,
     expandableRows,
-  } = processItems(allItems, state, options);
+  } = processItems(allItems, state, options, filteringPropertiesMap, defaultFilteringFunction, propertyFilterPredicate);
 
   const expandedItemsSet = new Set<string>();
   if (options.expandableRows) {
@@ -64,6 +83,24 @@ export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollect
   // When normal selection is used, the selectedItems are taken from state.
   // When group selection is used, the selectedItems are derived from group selection state.
   const extendedState = selectedItems ? { ...state, selectedItems } : state;
+
+  const filteringOptionsRef = useRef<{
+    allItems: ReadonlyArray<T> | null;
+    filteringProperties: typeof filteringProperties | null;
+    result: ReturnType<typeof computeFilteringOptions>;
+  }>({ allItems: null, filteringProperties: null, result: [] });
+  if (
+    filteringOptionsRef.current.allItems !== allItems ||
+    filteringOptionsRef.current.filteringProperties !== filteringProperties
+  ) {
+    filteringOptionsRef.current = {
+      allItems,
+      filteringProperties,
+      result: computeFilteringOptions(allItems, filteringProperties),
+    };
+  }
+  const filteringOptions = filteringOptionsRef.current.result;
+
   return {
     items,
     allPageItems,
@@ -75,6 +112,7 @@ export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollect
       allItems,
       totalItemsCount,
       expandableRows,
+      filteringOptions,
     }),
   };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,11 +9,38 @@ import {
   CollectionRef,
   PropertyFilterQuery,
   PropertyFilterOption,
+  PropertyFilterProperty,
   CollectionActions,
   GroupSelectionState,
   ExpandableRowsResultBase,
 } from './interfaces';
 import { fixupFalsyValues } from './operations/property-filter.js';
+
+export function computeFilteringOptions<T>(
+  allItems: readonly T[],
+  filteringProperties: readonly PropertyFilterProperty[] | undefined
+): PropertyFilterOption[] {
+  if (!filteringProperties) {
+    return [];
+  }
+  const result: PropertyFilterOption[] = [];
+  for (const property of filteringProperties) {
+    if (property.freeTextFilterable === false || property.dropdownFilterable === false) {
+      continue;
+    }
+    const key = property.key;
+    const seen: { [k: string]: boolean } = {};
+    for (const item of allItems) {
+      seen['' + fixupFalsyValues(item[key as keyof T])] = true;
+    }
+    for (const value of Object.keys(seen)) {
+      if (value !== '') {
+        result.push({ propertyKey: key, value });
+      }
+    }
+  }
+  return result;
+}
 
 interface SelectionAction<T> {
   type: 'selection';
@@ -138,12 +165,14 @@ export function createSyncProps<T>(
     allItems,
     totalItemsCount,
     expandableRows,
+    filteringOptions,
   }: {
     pagesCount?: number;
     actualPageIndex?: number;
     allItems: readonly T[];
     totalItemsCount: number;
     expandableRows?: ExpandableRowsResultBase<T>;
+    filteringOptions: PropertyFilterOption[];
   }
 ): Pick<UseCollectionResult<T>, 'collectionProps' | 'filterProps' | 'paginationProps' | 'propertyFilterProps'> {
   let empty: ReactNode | null = options.filtering
@@ -156,24 +185,6 @@ export function createSyncProps<T>(
       ? options.propertyFiltering.noMatch
       : options.propertyFiltering.empty
     : empty;
-  const filteringOptions = options.propertyFiltering
-    ? options.propertyFiltering.filteringProperties.reduce<PropertyFilterOption[]>((acc, property) => {
-        Object.keys(
-          allItems.reduce<{ [key in string]: boolean }>((acc, item) => {
-            acc['' + fixupFalsyValues(item[property.key as keyof T])] = true;
-            return acc;
-          }, {})
-        ).forEach(value => {
-          if (value !== '') {
-            acc.push({
-              propertyKey: property.key,
-              value,
-            });
-          }
-        });
-        return acc;
-      }, [])
-    : [];
 
   return {
     collectionProps: {


### PR DESCRIPTION
edit - closing in favor of https://github.com/cloudscape-design/collection-hooks/pull/142, which solely has the new flags. 


*Description of changes:*

- Extract filteringPropertiesMap build into makeFilteringPropertiesMap and memoize in useCollection on [filteringProperties], so the O(P) map construction only runs when filteringProperties reference changes rather than on every render.

- Extract filteringOptions scan into computeFilteringOptions and memoize in useCollection on [allItems, filteringProperties], so the O(N×P) scan only runs when data changes rather than on every sort, page, or filter render.

- Add freeTextFilteringProperties to propertyFiltering options. When provided, free-text tokens only search the specified properties. Property-specific tokens (key = value) are unaffected. When omitted, behavior is unchanged.

*Issue #, if available:* `AWSUI-61773`



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
