### PR TITLE
feat: add isFreeTextFilterable and generateDropdownOptions flags to PropertyFilterProperty

### DIFF
--- a/src/__tests__/operations/property-filter.test.ts
+++ b/src/__tests__/operations/property-filter.test.ts
@@ -890,9 +890,7 @@ describe('Token groups', () => {
 });
 
 describe('isFreeTextFilterable flag', () => {
-  const baseProps = [
-    { key: 'name', propertyLabel: 'Name', groupValuesLabel: '', operators: [':', '='] as const },
-  ];
+  const baseProps = [{ key: 'name', propertyLabel: 'Name', groupValuesLabel: '', operators: [':', '='] as const }];
   const items = [
     { name: 'alpha', tag: 'prod' },
     { name: 'beta', tag: 'prod' },
@@ -906,7 +904,13 @@ describe('isFreeTextFilterable flag', () => {
         propertyFiltering: {
           filteringProperties: [
             ...baseProps,
-            { key: 'tag', propertyLabel: 'Tag', groupValuesLabel: '', operators: [':', '='] as const, isFreeTextFilterable: false as const },
+            {
+              key: 'tag',
+              propertyLabel: 'Tag',
+              groupValuesLabel: '',
+              operators: [':', '='] as const,
+              isFreeTextFilterable: false as const,
+            },
           ],
         },
       }
@@ -922,7 +926,13 @@ describe('isFreeTextFilterable flag', () => {
         propertyFiltering: {
           filteringProperties: [
             ...baseProps,
-            { key: 'tag', propertyLabel: 'Tag', groupValuesLabel: '', operators: [':', '='] as const, isFreeTextFilterable: false as const },
+            {
+              key: 'tag',
+              propertyLabel: 'Tag',
+              groupValuesLabel: '',
+              operators: [':', '='] as const,
+              isFreeTextFilterable: false as const,
+            },
           ],
         },
       }
@@ -950,9 +960,19 @@ describe('isFreeTextFilterable flag', () => {
 describe('isFreeTextFilterable and generateFilteringOptions both false', () => {
   const props = [
     { key: 'name', propertyLabel: 'Name', groupValuesLabel: '', operators: [':', '='] as const },
-    { key: 'tag', propertyLabel: 'Tag', groupValuesLabel: '', operators: [':', '='] as const, isFreeTextFilterable: false as const, generateFilteringOptions: false as const },
+    {
+      key: 'tag',
+      propertyLabel: 'Tag',
+      groupValuesLabel: '',
+      operators: [':', '='] as const,
+      isFreeTextFilterable: false as const,
+      generateFilteringOptions: false as const,
+    },
   ];
-  const items = [{ name: 'alpha', tag: 'prod' }, { name: 'beta', tag: 'prod' }];
+  const items = [
+    { name: 'alpha', tag: 'prod' },
+    { name: 'beta', tag: 'prod' },
+  ];
 
   test('excluded from free-text search', () => {
     const { items: result } = processItems(

--- a/src/__tests__/operations/property-filter.test.ts
+++ b/src/__tests__/operations/property-filter.test.ts
@@ -888,3 +888,87 @@ describe('Token groups', () => {
     ]);
   });
 });
+
+describe('isFreeTextFilterable flag', () => {
+  const baseProps = [
+    { key: 'name', propertyLabel: 'Name', groupValuesLabel: '', operators: [':', '='] as const },
+  ];
+  const items = [
+    { name: 'alpha', tag: 'prod' },
+    { name: 'beta', tag: 'prod' },
+  ];
+
+  test('isFreeTextFilterable:false excludes column from free-text search', () => {
+    const { items: result } = processItems(
+      items,
+      { propertyFilteringQuery: { tokens: [{ operator: ':', value: 'prod' }], operation: 'and' } },
+      {
+        propertyFiltering: {
+          filteringProperties: [
+            ...baseProps,
+            { key: 'tag', propertyLabel: 'Tag', groupValuesLabel: '', operators: [':', '='] as const, isFreeTextFilterable: false as const },
+          ],
+        },
+      }
+    );
+    expect(result).toEqual([]);
+  });
+
+  test('isFreeTextFilterable:false does not affect property-specific tokens', () => {
+    const { items: result } = processItems(
+      items,
+      { propertyFilteringQuery: { tokens: [{ propertyKey: 'tag', operator: '=', value: 'prod' }], operation: 'and' } },
+      {
+        propertyFiltering: {
+          filteringProperties: [
+            ...baseProps,
+            { key: 'tag', propertyLabel: 'Tag', groupValuesLabel: '', operators: [':', '='] as const, isFreeTextFilterable: false as const },
+          ],
+        },
+      }
+    );
+    expect(result).toEqual(items);
+  });
+
+  test('without isFreeTextFilterable:false, free-text searches all columns', () => {
+    const { items: result } = processItems(
+      items,
+      { propertyFilteringQuery: { tokens: [{ operator: ':', value: 'prod' }], operation: 'and' } },
+      {
+        propertyFiltering: {
+          filteringProperties: [
+            ...baseProps,
+            { key: 'tag', propertyLabel: 'Tag', groupValuesLabel: '', operators: [':', '='] as const },
+          ],
+        },
+      }
+    );
+    expect(result).toEqual(items);
+  });
+});
+
+describe('isFreeTextFilterable and generateFilteringOptions both false', () => {
+  const props = [
+    { key: 'name', propertyLabel: 'Name', groupValuesLabel: '', operators: [':', '='] as const },
+    { key: 'tag', propertyLabel: 'Tag', groupValuesLabel: '', operators: [':', '='] as const, isFreeTextFilterable: false as const, generateFilteringOptions: false as const },
+  ];
+  const items = [{ name: 'alpha', tag: 'prod' }, { name: 'beta', tag: 'prod' }];
+
+  test('excluded from free-text search', () => {
+    const { items: result } = processItems(
+      items,
+      { propertyFilteringQuery: { tokens: [{ operator: ':', value: 'prod' }], operation: 'and' } },
+      { propertyFiltering: { filteringProperties: props } }
+    );
+    expect(result).toEqual([]);
+  });
+
+  test('still matches explicit property-keyed tokens', () => {
+    const { items: result } = processItems(
+      items,
+      { propertyFilteringQuery: { tokens: [{ propertyKey: 'tag', operator: '=', value: 'prod' }], operation: 'and' } },
+      { propertyFiltering: { filteringProperties: props } }
+    );
+    expect(result).toEqual(items);
+  });
+});

--- a/src/__tests__/use-collection.test.tsx
+++ b/src/__tests__/use-collection.test.tsx
@@ -589,3 +589,28 @@ describe('total items count and page range', () => {
     expect(getTotalItemsCount()).toEqual('4');
   });
 });
+
+describe('generateFilteringOptions flag', () => {
+  const props: readonly PropertyFilterProperty[] = [
+    { key: 'name', propertyLabel: 'Name', groupValuesLabel: '', operators: ['='] },
+    { key: 'tag', propertyLabel: 'Tag', groupValuesLabel: '', operators: ['='], generateFilteringOptions: false },
+  ];
+  const items = [{ name: 'alpha', tag: 'prod' }];
+
+  test('generateFilteringOptions:false excludes property from filteringOptions', () => {
+    function App() {
+      return (
+        <>
+          {JSON.stringify(
+            useCollection(items, { propertyFiltering: { filteringProperties: props } }).propertyFilterProps
+              .filteringOptions
+          )}
+        </>
+      );
+    }
+    const { container } = testRender(<App />);
+    const options: { propertyKey: string }[] = JSON.parse(container.textContent!);
+    expect(options.some(o => o.propertyKey === 'tag')).toBe(false);
+    expect(options.some(o => o.propertyKey === 'name')).toBe(true);
+  });
+});

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -218,6 +218,8 @@ export interface PropertyFilterProperty<TokenValue = any> {
   operators?: readonly (PropertyFilterOperator | PropertyFilterOperatorExtended<TokenValue>)[];
   defaultOperator?: PropertyFilterOperator;
   group?: string;
+  isFreeTextFilterable?: false;
+  generateFilteringOptions?: false;
 }
 
 export interface PropertyFilterOption {

--- a/src/operations/property-filter.ts
+++ b/src/operations/property-filter.ts
@@ -141,7 +141,7 @@ function freeTextFilter<T>(
   // If the operator is not a negation, we just need one property of the object to match.
   // If the operator is a negation, we want none of the properties of the object to match.
   const isNegation = operator.startsWith('!');
-  return Object.keys(filteringPropertiesMap)[isNegation ? 'every' : 'some'](propertyKey => {
+  return Object.keys(filteringPropertiesMap).filter(k => filteringPropertiesMap[k as keyof FilteringPropertiesMap<T>].isFreeTextFilterable)[isNegation ? 'every' : 'some'](propertyKey => {
     const { operators } = filteringPropertiesMap[propertyKey as keyof typeof filteringPropertiesMap];
     const propertyOperator = operators[operator];
     if (!propertyOperator) {
@@ -201,6 +201,8 @@ function defaultFilteringFunction<T>(filteringPropertiesMap: FilteringProperties
 type FilteringPropertiesMap<T> = {
   [key in keyof T]: {
     operators: FilteringOperatorsMap;
+    isFreeTextFilterable: boolean;
+    generateFilteringOptions: boolean;
   };
 };
 
@@ -216,7 +218,7 @@ export function createPropertyFilterPredicate<T>(
     return null;
   }
   const filteringPropertiesMap = propertyFiltering.filteringProperties.reduce<FilteringPropertiesMap<T>>(
-    (acc: FilteringPropertiesMap<T>, { key, operators, defaultOperator }: PropertyFilterProperty) => {
+    (acc: FilteringPropertiesMap<T>, { key, operators, defaultOperator, isFreeTextFilterable, generateFilteringOptions }: PropertyFilterProperty) => {
       const operatorMap: FilteringOperatorsMap = { [defaultOperator ?? '=']: { operator: defaultOperator ?? '=' } };
       operators?.forEach(op => {
         if (typeof op === 'string') {
@@ -225,7 +227,7 @@ export function createPropertyFilterPredicate<T>(
           operatorMap[op.operator] = { operator: op.operator, match: op.match, tokenType: op.tokenType };
         }
       });
-      acc[key as keyof T] = { operators: operatorMap };
+      acc[key as keyof T] = { operators: operatorMap, isFreeTextFilterable: isFreeTextFilterable !== false, generateFilteringOptions: generateFilteringOptions !== false };
       return acc;
     },
     {} as FilteringPropertiesMap<T>

--- a/src/operations/property-filter.ts
+++ b/src/operations/property-filter.ts
@@ -141,14 +141,16 @@ function freeTextFilter<T>(
   // If the operator is not a negation, we just need one property of the object to match.
   // If the operator is a negation, we want none of the properties of the object to match.
   const isNegation = operator.startsWith('!');
-  return Object.keys(filteringPropertiesMap).filter(k => filteringPropertiesMap[k as keyof FilteringPropertiesMap<T>].isFreeTextFilterable)[isNegation ? 'every' : 'some'](propertyKey => {
-    const { operators } = filteringPropertiesMap[propertyKey as keyof typeof filteringPropertiesMap];
-    const propertyOperator = operators[operator];
-    if (!propertyOperator) {
-      return isNegation;
-    }
-    return filterUsingOperator(item[propertyKey as keyof typeof item], { tokenValue, operator: propertyOperator });
-  });
+  return Object.keys(filteringPropertiesMap)
+    .filter(k => filteringPropertiesMap[k as keyof FilteringPropertiesMap<T>].isFreeTextFilterable)
+    [isNegation ? 'every' : 'some'](propertyKey => {
+      const { operators } = filteringPropertiesMap[propertyKey as keyof typeof filteringPropertiesMap];
+      const propertyOperator = operators[operator];
+      if (!propertyOperator) {
+        return isNegation;
+      }
+      return filterUsingOperator(item[propertyKey as keyof typeof item], { tokenValue, operator: propertyOperator });
+    });
 }
 
 function filterByToken<T>(token: PropertyFilterToken, item: T, filteringPropertiesMap: FilteringPropertiesMap<T>) {
@@ -218,7 +220,10 @@ export function createPropertyFilterPredicate<T>(
     return null;
   }
   const filteringPropertiesMap = propertyFiltering.filteringProperties.reduce<FilteringPropertiesMap<T>>(
-    (acc: FilteringPropertiesMap<T>, { key, operators, defaultOperator, isFreeTextFilterable, generateFilteringOptions }: PropertyFilterProperty) => {
+    (
+      acc: FilteringPropertiesMap<T>,
+      { key, operators, defaultOperator, isFreeTextFilterable, generateFilteringOptions }: PropertyFilterProperty
+    ) => {
       const operatorMap: FilteringOperatorsMap = { [defaultOperator ?? '=']: { operator: defaultOperator ?? '=' } };
       operators?.forEach(op => {
         if (typeof op === 'string') {
@@ -227,7 +232,11 @@ export function createPropertyFilterPredicate<T>(
           operatorMap[op.operator] = { operator: op.operator, match: op.match, tokenType: op.tokenType };
         }
       });
-      acc[key as keyof T] = { operators: operatorMap, isFreeTextFilterable: isFreeTextFilterable !== false, generateFilteringOptions: generateFilteringOptions !== false };
+      acc[key as keyof T] = {
+        operators: operatorMap,
+        isFreeTextFilterable: isFreeTextFilterable !== false,
+        generateFilteringOptions: generateFilteringOptions !== false,
+      };
       return acc;
     },
     {} as FilteringPropertiesMap<T>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -158,6 +158,9 @@ export function createSyncProps<T>(
     : empty;
   const filteringOptions = options.propertyFiltering
     ? options.propertyFiltering.filteringProperties.reduce<PropertyFilterOption[]>((acc, property) => {
+        if (property.generateFilteringOptions === false) {
+          return acc;
+        }
         Object.keys(
           allItems.reduce<{ [key in string]: boolean }>((acc, item) => {
             acc['' + fixupFalsyValues(item[property.key as keyof T])] = true;


### PR DESCRIPTION
*Description of changes:*

Adds two opt-out flags to the `PropertyFilterProperty` interface:

- `isFreeTextFilterable?: false` - excludes the property from free-text token matching

- `generateDropdownOptions?: false` - excludes the property from `filteringOptions` (dropdown suggestions)

Both flags are absent-means-enabled (?: false typed), so existing callers are unaffected.

Note that a property with both flags set is still filterable via explicit property-keyed tokens (e.g. `{ propertyKey: 'tag', operator: '=', value: 'prod' })`, but will not appear in free-text search or dropdown suggestions.

*Issue #, if available:* `AWSUI-61773`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
