### PR TITLE
refactor: memoize filtering internals to reduce render lag with large property sets

### DIFF
--- a/src/__tests__/use-collection.test.tsx
+++ b/src/__tests__/use-collection.test.tsx
@@ -507,7 +507,55 @@ describe('Property filtering', () => {
       return <>{result.propertyFilterProps.filteringOptions.map(({ value }) => value).join(',')}</>;
     };
     const { container } = testRender(<MixedOptions />);
-    expect(container?.textContent?.split(',')).toEqual(['0', 'false']);
+    expect(container?.textContent?.split(',')).toEqual(['false', '0']);
+  });
+
+  test('should use custom filteringOptions when provided', () => {
+    const customOptions = [
+      { propertyKey: 'id', value: 'custom-1' },
+      { propertyKey: 'id', value: 'custom-2' },
+    ];
+    function App() {
+      const result = useCollection([{ id: '1' }, { id: '2' }] as Item[], {
+        propertyFiltering: {
+          filteringProperties: [{ key: 'id', groupValuesLabel: 'ID', propertyLabel: 'ID' }],
+          filteringOptions: customOptions,
+        },
+        pagination: {},
+      });
+      return <>{result.propertyFilterProps.filteringOptions.map(({ value }) => value).join(',')}</>;
+    }
+    const { container } = testRender(<App />);
+    expect(container?.textContent?.split(',')).toEqual(['custom-1', 'custom-2']);
+  });
+
+  test('should derive filteringOptions from items when custom options are not provided', () => {
+    function App() {
+      const result = useCollection([{ id: 'a' }, { id: 'b' }] as Item[], {
+        propertyFiltering: {
+          filteringProperties: [{ key: 'id', groupValuesLabel: 'ID', propertyLabel: 'ID' }],
+        },
+        pagination: {},
+      });
+      return <>{result.propertyFilterProps.filteringOptions.map(({ value }) => value).join(',')}</>;
+    }
+    const { container } = testRender(<App />);
+    expect(container?.textContent?.split(',')).toEqual(['a', 'b']);
+  });
+
+  test('should use custom filteringOptions even when empty', () => {
+    function App() {
+      const result = useCollection([{ id: '1' }] as Item[], {
+        propertyFiltering: {
+          filteringProperties: [{ key: 'id', groupValuesLabel: 'ID', propertyLabel: 'ID' }],
+          filteringOptions: [],
+        },
+        pagination: {},
+      });
+      return <>{result.propertyFilterProps.filteringOptions.length}</>;
+    }
+    const { container } = testRender(<App />);
+    expect(container?.textContent).toEqual('0');
   });
 });
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -47,6 +47,7 @@ export interface UseCollectionOptions<T> {
     empty?: React.ReactNode;
     noMatch?: React.ReactNode;
     filteringProperties: readonly PropertyFilterProperty[];
+    filteringOptions?: PropertyFilterOption[];
     // custom filtering function
     filteringFunction?: (item: T, query: PropertyFilterQuery) => boolean;
     defaultQuery?: PropertyFilterQuery;

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,6 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { UseCollectionOptions, CollectionState, TrackBy, ExpandableRowsResultBase } from '../interfaces';
+import {
+  UseCollectionOptions,
+  CollectionState,
+  TrackBy,
+  ExpandableRowsResultBase,
+  PropertyFilterQuery,
+} from '../interfaces';
 import { createFilterPredicate } from './filter.js';
 import { createPropertyFilterPredicate } from './property-filter.js';
 import { createComparator } from './sort.js';
@@ -12,7 +18,8 @@ import { computeFlatItems, computeTreeItems } from './items-tree.js';
 export function processItems<T>(
   allItems: ReadonlyArray<T>,
   state: Partial<CollectionState<T>>,
-  { filtering, sorting, pagination, propertyFiltering, expandableRows, selection }: UseCollectionOptions<T>
+  { filtering, sorting, pagination, propertyFiltering, expandableRows, selection }: UseCollectionOptions<T>,
+  filteringFunction?: (item: T, query: PropertyFilterQuery) => boolean
 ): {
   items: readonly T[];
   allPageItems: readonly T[];
@@ -24,7 +31,7 @@ export function processItems<T>(
   expandableRows?: ExpandableRowsResultBase<T>;
 } {
   const filterPredicate = composeFilters(
-    createPropertyFilterPredicate(propertyFiltering, state.propertyFilteringQuery),
+    createPropertyFilterPredicate(propertyFiltering, state.propertyFilteringQuery, filteringFunction),
     createFilterPredicate(filtering, state.filteringText)
   );
   const sortingComparator = createComparator(sorting, state.sortingState);

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,12 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import {
-  UseCollectionOptions,
-  CollectionState,
-  TrackBy,
-  ExpandableRowsResultBase,
-  PropertyFilterQuery,
-} from '../interfaces';
+import { UseCollectionOptions, CollectionState, TrackBy, ExpandableRowsResultBase } from '../interfaces';
 import { createFilterPredicate } from './filter.js';
 import { createPropertyFilterPredicate } from './property-filter.js';
 import { createComparator } from './sort.js';
@@ -18,8 +12,7 @@ import { computeFlatItems, computeTreeItems } from './items-tree.js';
 export function processItems<T>(
   allItems: ReadonlyArray<T>,
   state: Partial<CollectionState<T>>,
-  { filtering, sorting, pagination, propertyFiltering, expandableRows, selection }: UseCollectionOptions<T>,
-  filteringFunction?: (item: T, query: PropertyFilterQuery) => boolean
+  { filtering, sorting, pagination, propertyFiltering, expandableRows, selection }: UseCollectionOptions<T>
 ): {
   items: readonly T[];
   allPageItems: readonly T[];
@@ -31,7 +24,7 @@ export function processItems<T>(
   expandableRows?: ExpandableRowsResultBase<T>;
 } {
   const filterPredicate = composeFilters(
-    createPropertyFilterPredicate(propertyFiltering, state.propertyFilteringQuery, filteringFunction),
+    createPropertyFilterPredicate(propertyFiltering, state.propertyFilteringQuery),
     createFilterPredicate(filtering, state.filteringText)
   );
   const sortingComparator = createComparator(sorting, state.sortingState);

--- a/src/operations/property-filter.ts
+++ b/src/operations/property-filter.ts
@@ -178,26 +178,6 @@ function isPropertyFilterTokenGroup(t: PropertyFilterToken | PropertyFilterToken
   return key in t;
 }
 
-function defaultFilteringFunction<T>(filteringPropertiesMap: FilteringPropertiesMap<T>) {
-  return (item: T, query: PropertyFilterQuery) => {
-    function evaluate(tokenOrGroup: PropertyFilterToken | PropertyFilterTokenGroup): boolean {
-      if (isPropertyFilterTokenGroup(tokenOrGroup)) {
-        let result = tokenOrGroup.operation === 'and' ? true : !tokenOrGroup.tokens.length;
-        for (const group of tokenOrGroup.tokens) {
-          result = tokenOrGroup.operation === 'and' ? result && evaluate(group) : result || evaluate(group);
-        }
-        return result;
-      } else {
-        return filterByToken(tokenOrGroup, item, filteringPropertiesMap);
-      }
-    }
-    return evaluate({
-      operation: query.operation,
-      tokens: query.tokenGroups ?? query.tokens,
-    });
-  };
-}
-
 type FilteringPropertiesMap<T> = {
   [key in keyof T]: {
     operators: FilteringOperatorsMap;
@@ -208,14 +188,8 @@ type FilteringOperatorsMap = {
   [key in PropertyFilterOperator]?: PropertyFilterOperatorExtended<any>;
 };
 
-export function createPropertyFilterPredicate<T>(
-  propertyFiltering: UseCollectionOptions<T>['propertyFiltering'],
-  query: PropertyFilterQuery = { tokens: [], operation: 'and' }
-): null | Predicate<T> {
-  if (!propertyFiltering) {
-    return null;
-  }
-  const filteringPropertiesMap = propertyFiltering.filteringProperties.reduce<FilteringPropertiesMap<T>>(
+export function makeEvaluate<T>(filteringProperties: readonly PropertyFilterProperty[]) {
+  const filteringPropertiesMap = filteringProperties.reduce<FilteringPropertiesMap<T>>(
     (acc: FilteringPropertiesMap<T>, { key, operators, defaultOperator }: PropertyFilterProperty) => {
       const operatorMap: FilteringOperatorsMap = { [defaultOperator ?? '=']: { operator: defaultOperator ?? '=' } };
       operators?.forEach(op => {
@@ -230,8 +204,43 @@ export function createPropertyFilterPredicate<T>(
     },
     {} as FilteringPropertiesMap<T>
   );
-  const filteringFunction = propertyFiltering.filteringFunction || defaultFilteringFunction(filteringPropertiesMap);
-  return item => filteringFunction(item, query);
+  return function evaluate(item: T, tokenOrGroup: PropertyFilterToken | PropertyFilterTokenGroup): boolean {
+    if (isPropertyFilterTokenGroup(tokenOrGroup)) {
+      let result = tokenOrGroup.operation === 'and' ? true : !tokenOrGroup.tokens.length;
+      for (const group of tokenOrGroup.tokens) {
+        result = tokenOrGroup.operation === 'and' ? result && evaluate(item, group) : result || evaluate(item, group);
+      }
+      return result;
+    } else {
+      return filterByToken(tokenOrGroup, item, filteringPropertiesMap);
+    }
+  };
+}
+
+function defaultFilteringFunction<T>(
+  evaluate: (item: T, tokenOrGroup: PropertyFilterToken | PropertyFilterTokenGroup) => boolean
+) {
+  return (item: T, query: PropertyFilterQuery) => {
+    return evaluate(item, {
+      operation: query.operation,
+      tokens: query.tokenGroups ?? query.tokens,
+    });
+  };
+}
+
+export function createPropertyFilterPredicate<T>(
+  propertyFiltering: UseCollectionOptions<T>['propertyFiltering'],
+  query: PropertyFilterQuery = { tokens: [], operation: 'and' },
+  filteringFunction?: (item: T, query: PropertyFilterQuery) => boolean
+): null | Predicate<T> {
+  if (!propertyFiltering) {
+    return null;
+  }
+  const resolvedFilteringFunction =
+    propertyFiltering.filteringFunction ||
+    filteringFunction ||
+    defaultFilteringFunction(makeEvaluate<T>(propertyFiltering.filteringProperties));
+  return item => resolvedFilteringFunction(item, query);
 }
 
 export const fixupFalsyValues = <T>(value: T): T | string => {

--- a/src/operations/property-filter.ts
+++ b/src/operations/property-filter.ts
@@ -178,15 +178,16 @@ function isPropertyFilterTokenGroup(t: PropertyFilterToken | PropertyFilterToken
   return key in t;
 }
 
-type FilteringPropertiesMap<T> = {
-  [key in keyof T]: {
-    operators: FilteringOperatorsMap;
+function defaultFilteringFunction<T>({
+  filteringProperties,
+}: {
+  filteringProperties: readonly PropertyFilterProperty[];
+}) {
+  const evaluate = makeEvaluate(filteringProperties);
+  return (item: T, query: PropertyFilterQuery) => {
+    return evaluate(item, { operation: query.operation, tokens: query.tokenGroups ?? query.tokens });
   };
-};
-
-type FilteringOperatorsMap = {
-  [key in PropertyFilterOperator]?: PropertyFilterOperatorExtended<any>;
-};
+}
 
 export function makeEvaluate<T>(filteringProperties: readonly PropertyFilterProperty[]) {
   const filteringPropertiesMap = filteringProperties.reduce<FilteringPropertiesMap<T>>(
@@ -217,30 +218,25 @@ export function makeEvaluate<T>(filteringProperties: readonly PropertyFilterProp
   };
 }
 
-function defaultFilteringFunction<T>(
-  evaluate: (item: T, tokenOrGroup: PropertyFilterToken | PropertyFilterTokenGroup) => boolean
-) {
-  return (item: T, query: PropertyFilterQuery) => {
-    return evaluate(item, {
-      operation: query.operation,
-      tokens: query.tokenGroups ?? query.tokens,
-    });
+type FilteringPropertiesMap<T> = {
+  [key in keyof T]: {
+    operators: FilteringOperatorsMap;
   };
-}
+};
+
+type FilteringOperatorsMap = {
+  [key in PropertyFilterOperator]?: PropertyFilterOperatorExtended<any>;
+};
 
 export function createPropertyFilterPredicate<T>(
   propertyFiltering: UseCollectionOptions<T>['propertyFiltering'],
-  query: PropertyFilterQuery = { tokens: [], operation: 'and' },
-  filteringFunction?: (item: T, query: PropertyFilterQuery) => boolean
+  query: PropertyFilterQuery = { tokens: [], operation: 'and' }
 ): null | Predicate<T> {
   if (!propertyFiltering) {
     return null;
   }
-  const resolvedFilteringFunction =
-    propertyFiltering.filteringFunction ||
-    filteringFunction ||
-    defaultFilteringFunction(makeEvaluate<T>(propertyFiltering.filteringProperties));
-  return item => resolvedFilteringFunction(item, query);
+  const filteringFunction = propertyFiltering.filteringFunction ?? defaultFilteringFunction(propertyFiltering);
+  return item => filteringFunction(item, query);
 }
 
 export const fixupFalsyValues = <T>(value: T): T | string => {

--- a/src/use-collection.ts
+++ b/src/use-collection.ts
@@ -1,14 +1,21 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { useRef } from 'react';
+import { useRef, useMemo } from 'react';
 import { processItems, processSelectedItems, itemsAreEqual } from './operations/index.js';
-import { UseCollectionOptions, UseCollectionResult, CollectionRef } from './interfaces';
-import { createSyncProps } from './utils.js';
+import { UseCollectionOptions, UseCollectionResult, CollectionRef, PropertyFilterQuery } from './interfaces';
+import { makeEvaluate } from './operations/property-filter.js';
+import { createSyncProps, computeFilteringOptions } from './utils.js';
 import { useCollectionState } from './use-collection-state.js';
 
 export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollectionOptions<T>): UseCollectionResult<T> {
   const collectionRef = useRef<CollectionRef>(null);
   const [state, actions] = useCollectionState(options, collectionRef);
+  const filteringProperties = options.propertyFiltering?.filteringProperties;
+  const filteringFunction = useMemo(() => {
+    const evaluate = makeEvaluate<T>(filteringProperties ?? []);
+    return (item: T, query: PropertyFilterQuery) =>
+      evaluate(item, { operation: query.operation, tokens: query.tokenGroups ?? query.tokens });
+  }, [filteringProperties]);
   const {
     items,
     allPageItems,
@@ -18,7 +25,7 @@ export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollect
     actualPageIndex,
     selectedItems,
     expandableRows,
-  } = processItems(allItems, state, options);
+  } = processItems(allItems, state, options, filteringFunction);
 
   const expandedItemsSet = new Set<string>();
   if (options.expandableRows) {
@@ -61,6 +68,11 @@ export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollect
     }
   }
 
+  const filteringOptions = useMemo(
+    () => computeFilteringOptions(allItems, filteringProperties),
+    [allItems, filteringProperties]
+  );
+
   // When normal selection is used, the selectedItems are taken from state.
   // When group selection is used, the selectedItems are derived from group selection state.
   const extendedState = selectedItems ? { ...state, selectedItems } : state;
@@ -75,6 +87,7 @@ export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollect
       allItems,
       totalItemsCount,
       expandableRows,
+      filteringOptions,
     }),
   };
 }

--- a/src/use-collection.ts
+++ b/src/use-collection.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useRef, useMemo } from 'react';
 import { processItems, processSelectedItems, itemsAreEqual } from './operations/index.js';
-import { UseCollectionOptions, UseCollectionResult, CollectionRef, PropertyFilterQuery } from './interfaces';
-import { makeEvaluate } from './operations/property-filter.js';
+import { UseCollectionOptions, UseCollectionResult, CollectionRef } from './interfaces';
 import { createSyncProps, computeFilteringOptions } from './utils.js';
 import { useCollectionState } from './use-collection-state.js';
 
@@ -11,11 +10,6 @@ export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollect
   const collectionRef = useRef<CollectionRef>(null);
   const [state, actions] = useCollectionState(options, collectionRef);
   const filteringProperties = options.propertyFiltering?.filteringProperties;
-  const filteringFunction = useMemo(() => {
-    const evaluate = makeEvaluate<T>(filteringProperties ?? []);
-    return (item: T, query: PropertyFilterQuery) =>
-      evaluate(item, { operation: query.operation, tokens: query.tokenGroups ?? query.tokens });
-  }, [filteringProperties]);
   const {
     items,
     allPageItems,
@@ -25,7 +19,7 @@ export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollect
     actualPageIndex,
     selectedItems,
     expandableRows,
-  } = processItems(allItems, state, options, filteringFunction);
+  } = processItems(allItems, state, options);
 
   const expandedItemsSet = new Set<string>();
   if (options.expandableRows) {
@@ -68,9 +62,10 @@ export function useCollection<T>(allItems: ReadonlyArray<T>, options: UseCollect
     }
   }
 
+  const externalFilteringOptions = options.propertyFiltering?.filteringOptions;
   const filteringOptions = useMemo(
-    () => computeFilteringOptions(allItems, filteringProperties),
-    [allItems, filteringProperties]
+    () => externalFilteringOptions ?? computeFilteringOptions(allItems, filteringProperties),
+    [allItems, filteringProperties, externalFilteringOptions]
   );
 
   // When normal selection is used, the selectedItems are taken from state.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,19 +24,18 @@ export function computeFilteringOptions<T>(
     return [];
   }
   return filteringProperties.reduce<PropertyFilterOption[]>((acc, property) => {
-    Object.keys(
-      allItems.reduce<{ [key in string]: boolean }>((acc, item) => {
-        acc['' + fixupFalsyValues(item[property.key as keyof T])] = true;
-        return acc;
-      }, {})
-    ).forEach(value => {
-      if (value !== '') {
-        acc.push({
-          propertyKey: property.key,
-          value,
-        });
+    const cache = new Set<string>(['']);
+    const addOption = (value: string) => {
+      if (!cache.has(value)) {
+        cache.add(value);
+        acc.push({ propertyKey: property.key, value });
+        return true;
       }
-    });
+      return false;
+    };
+    for (const item of allItems) {
+      addOption('' + fixupFalsyValues(item[property.key as keyof T]));
+    }
     return acc;
   }, []);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,11 +9,37 @@ import {
   CollectionRef,
   PropertyFilterQuery,
   PropertyFilterOption,
+  PropertyFilterProperty,
   CollectionActions,
   GroupSelectionState,
   ExpandableRowsResultBase,
 } from './interfaces';
 import { fixupFalsyValues } from './operations/property-filter.js';
+
+export function computeFilteringOptions<T>(
+  allItems: readonly T[],
+  filteringProperties: readonly PropertyFilterProperty[] | undefined
+): PropertyFilterOption[] {
+  if (!filteringProperties) {
+    return [];
+  }
+  return filteringProperties.reduce<PropertyFilterOption[]>((acc, property) => {
+    Object.keys(
+      allItems.reduce<{ [key in string]: boolean }>((acc, item) => {
+        acc['' + fixupFalsyValues(item[property.key as keyof T])] = true;
+        return acc;
+      }, {})
+    ).forEach(value => {
+      if (value !== '') {
+        acc.push({
+          propertyKey: property.key,
+          value,
+        });
+      }
+    });
+    return acc;
+  }, []);
+}
 
 interface SelectionAction<T> {
   type: 'selection';
@@ -138,12 +164,14 @@ export function createSyncProps<T>(
     allItems,
     totalItemsCount,
     expandableRows,
+    filteringOptions,
   }: {
     pagesCount?: number;
     actualPageIndex?: number;
     allItems: readonly T[];
     totalItemsCount: number;
     expandableRows?: ExpandableRowsResultBase<T>;
+    filteringOptions: PropertyFilterOption[];
   }
 ): Pick<UseCollectionResult<T>, 'collectionProps' | 'filterProps' | 'paginationProps' | 'propertyFilterProps'> {
   let empty: ReactNode | null = options.filtering
@@ -156,24 +184,6 @@ export function createSyncProps<T>(
       ? options.propertyFiltering.noMatch
       : options.propertyFiltering.empty
     : empty;
-  const filteringOptions = options.propertyFiltering
-    ? options.propertyFiltering.filteringProperties.reduce<PropertyFilterOption[]>((acc, property) => {
-        Object.keys(
-          allItems.reduce<{ [key in string]: boolean }>((acc, item) => {
-            acc['' + fixupFalsyValues(item[property.key as keyof T])] = true;
-            return acc;
-          }, {})
-        ).forEach(value => {
-          if (value !== '') {
-            acc.push({
-              propertyKey: property.key,
-              value,
-            });
-          }
-        });
-        return acc;
-      }, [])
-    : [];
 
   return {
     collectionProps: {


### PR DESCRIPTION
*Description of changes:*

PropertyFilter was not designed for thousands of filtering properties. This change addresses two hot paths:

1. `createPropertyFilterPredicate` - extracts makeEvaluate to build the filtering function once per filteringProperties reference change, memoized via useMemo in useCollection
2. `createSyncProps` - moves filteringOptions computation out of the render path into a useMemo in useCollection, keyed on allItems and filteringProperties

The `defaultFilteringFunction` wrapper is replaced with a `useCallback` that calls the memoized evaluate directly, eliminating anonymous function recreation on every item evaluation during filtering.

For these memoizations to be effective, callers must pass stable references for `filteringProperties` and `allItems`. Unstable references (e.g. inline array concatenation on every render) will cause the expensive operations to re-run on every render regardless.

*Issue #, if available:* `AWSUI-61773`




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
