### PR TITLE
refactor: Refactors property filter tests setup

### DIFF
--- a/src/__tests__/operations/property-filter.test.ts
+++ b/src/__tests__/operations/property-filter.test.ts
@@ -1,9 +1,18 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { test, expect, describe, vi } from 'vitest';
-import { processItems } from '../../operations';
-import { PropertyFilterOperator } from '../../interfaces';
+import { PropertyFilterOperator, PropertyFilterQuery, UseCollectionOptions } from '../../interfaces';
 import * as logging from '../../logging';
+import { renderUseCollection } from '../utils';
+
+function processItems<T>(
+  items: readonly T[],
+  state: { propertyFilteringQuery?: PropertyFilterQuery },
+  options: Pick<UseCollectionOptions<T>, 'propertyFiltering'>
+) {
+  const propertyFiltering = { ...options.propertyFiltering!, defaultQuery: state.propertyFilteringQuery };
+  return renderUseCollection(items, { ...options, propertyFiltering }).result;
+}
 
 const propertyFiltering = {
   filteringProperties: [


### PR DESCRIPTION
A small refactor to support https://github.com/cloudscape-design/collection-hooks/pull/143.

This makes property filter tests run via useCollection, to ensure the related code such as memoized filtering function works correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
