### PR TITLE
chore: New type for property filter free text operator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export {
   CollectionRef,
   FilteringOptions,
   PropertyFilterFreeTextFiltering,
+  PropertyFilterFreeTextOperator,
   PropertyFilterOperation,
   PropertyFilterOperator,
   PropertyFilterOperatorExtended,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -164,7 +164,7 @@ export interface CollectionRef {
   scrollToTop: () => void;
 }
 
-export type PropertyFilterOperator = '<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=' | '^' | string;
+export type PropertyFilterOperator = '<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=' | '^' | '!^' | string;
 
 export interface PropertyFilterOperatorExtended<TokenValue> {
   operator: PropertyFilterOperator;
@@ -229,6 +229,8 @@ export interface PropertyFilterOption {
   filteringTags?: ReadonlyArray<string>;
 }
 export interface PropertyFilterFreeTextFiltering {
-  operators?: readonly PropertyFilterOperator[];
+  operators?: readonly PropertyFilterFreeTextOperator[];
   defaultOperator?: PropertyFilterOperator;
 }
+
+export type PropertyFilterFreeTextOperator = PropertyFilterOperator;


### PR DESCRIPTION
Introducing new type for property filter free text operator. This allows us to extend the type definition in the follow-up PR to add support for extended operators (https://github.com/cloudscape-design/collection-hooks/pull/144).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
