### PR TITLE
feat: add description field to PropertyFilterOperatorExtended

### DIFF
--- a/src/__tests__/operations/property-filter.test.ts
+++ b/src/__tests__/operations/property-filter.test.ts
@@ -357,6 +357,147 @@ test('unsupported operator results in an exception', () => {
   ).toThrow('Unsupported operator given.');
 });
 
+describe('custom operators', () => {
+  test('custom operator with match function filters items', () => {
+    const items = [{ field: 'app-web-prod' }, { field: 'app-api-staging' }, { field: 'app-worker-prod' }];
+    const { items: processed } = processItems(
+      items,
+      {
+        propertyFilteringQuery: {
+          tokens: [{ propertyKey: 'field', operator: '~', value: 'app-.*-prod' }],
+          operation: 'and',
+        },
+      },
+      {
+        propertyFiltering: {
+          filteringProperties: [
+            {
+              key: 'field',
+              operators: [
+                {
+                  operator: '~',
+                  match: (itemValue, tokenValue) => new RegExp(tokenValue).test(String(itemValue)),
+                },
+              ],
+              propertyLabel: 'Field',
+              groupValuesLabel: 'Field values',
+            },
+          ],
+        },
+      }
+    );
+    expect(processed).toEqual([items[0], items[2]]);
+  });
+
+  test('custom operator without match function throws', () => {
+    const items = [{ field: 'test' }];
+    expect(() =>
+      processItems(
+        items,
+        {
+          propertyFilteringQuery: {
+            tokens: [{ propertyKey: 'field', operator: '~', value: 'test' }],
+            operation: 'and',
+          },
+        },
+        {
+          propertyFiltering: {
+            filteringProperties: [
+              {
+                key: 'field',
+                operators: ['~'],
+                propertyLabel: 'Field',
+                groupValuesLabel: 'Field values',
+              },
+            ],
+          },
+        }
+      )
+    ).toThrow('Unsupported operator given.');
+  });
+
+  test('custom match on predefined operator overrides default behavior', () => {
+    const items = [{ field: 'hello world' }, { field: 'HELLO WORLD' }, { field: 'goodbye' }];
+    const { items: processed } = processItems(
+      items,
+      {
+        propertyFilteringQuery: {
+          tokens: [{ propertyKey: 'field', operator: '=', value: 'hello world' }],
+          operation: 'and',
+        },
+      },
+      {
+        propertyFiltering: {
+          filteringProperties: [
+            {
+              key: 'field',
+              operators: [
+                {
+                  operator: '=',
+                  match: (itemValue: unknown, tokenValue: unknown) =>
+                    String(itemValue).toLowerCase() === String(tokenValue).toLowerCase(),
+                },
+              ],
+              propertyLabel: 'Field',
+              groupValuesLabel: 'Field values',
+            },
+          ],
+        },
+      }
+    );
+    // Default "=" uses == which is case-sensitive. Custom match is case-insensitive.
+    expect(processed).toEqual([items[0], items[1]]);
+  });
+
+  test('custom operator works in free text filtering across properties', () => {
+    const items = [
+      { name: 'app-web-prod', env: 'production' },
+      { name: 'app-api-staging', env: 'staging' },
+      { name: 'svc-auth-prod', env: 'production' },
+    ];
+    const { items: processed } = processItems(
+      items,
+      {
+        propertyFilteringQuery: {
+          tokens: [{ operator: '~', value: 'prod' }],
+          operation: 'and',
+        },
+      },
+      {
+        propertyFiltering: {
+          filteringProperties: [
+            {
+              key: 'name',
+              operators: [
+                {
+                  operator: '~',
+                  match: (itemValue: unknown, tokenValue: unknown) =>
+                    new RegExp(String(tokenValue)).test(String(itemValue)),
+                },
+              ],
+              propertyLabel: 'Name',
+              groupValuesLabel: 'Name values',
+            },
+            {
+              key: 'env',
+              operators: [
+                {
+                  operator: '~',
+                  match: (itemValue: unknown, tokenValue: unknown) =>
+                    new RegExp(String(tokenValue)).test(String(itemValue)),
+                },
+              ],
+              propertyLabel: 'Environment',
+              groupValuesLabel: 'Environment values',
+            },
+          ],
+        },
+      }
+    );
+    expect(processed).toEqual([items[0], items[2]]);
+  });
+});
+
 describe('filtering function', () => {
   test('Is called with the current query', () => {
     const items = [{ id: 1, field: 'match me' }];

--- a/src/__tests__/operations/property-filter.test.ts
+++ b/src/__tests__/operations/property-filter.test.ts
@@ -389,66 +389,6 @@ describe('custom operators', () => {
     expect(processed).toEqual([items[0], items[2]]);
   });
 
-  test('custom operator without match function throws', () => {
-    const items = [{ field: 'test' }];
-    expect(() =>
-      processItems(
-        items,
-        {
-          propertyFilteringQuery: {
-            tokens: [{ propertyKey: 'field', operator: '~', value: 'test' }],
-            operation: 'and',
-          },
-        },
-        {
-          propertyFiltering: {
-            filteringProperties: [
-              {
-                key: 'field',
-                operators: ['~'],
-                propertyLabel: 'Field',
-                groupValuesLabel: 'Field values',
-              },
-            ],
-          },
-        }
-      )
-    ).toThrow('Unsupported operator given.');
-  });
-
-  test('custom match on predefined operator overrides default behavior', () => {
-    const items = [{ field: 'hello world' }, { field: 'HELLO WORLD' }, { field: 'goodbye' }];
-    const { items: processed } = processItems(
-      items,
-      {
-        propertyFilteringQuery: {
-          tokens: [{ propertyKey: 'field', operator: '=', value: 'hello world' }],
-          operation: 'and',
-        },
-      },
-      {
-        propertyFiltering: {
-          filteringProperties: [
-            {
-              key: 'field',
-              operators: [
-                {
-                  operator: '=',
-                  match: (itemValue: unknown, tokenValue: unknown) =>
-                    String(itemValue).toLowerCase() === String(tokenValue).toLowerCase(),
-                },
-              ],
-              propertyLabel: 'Field',
-              groupValuesLabel: 'Field values',
-            },
-          ],
-        },
-      }
-    );
-    // Default "=" uses == which is case-sensitive. Custom match is case-insensitive.
-    expect(processed).toEqual([items[0], items[1]]);
-  });
-
   test('custom operator works in free text filtering across properties', () => {
     const items = [
       { name: 'app-web-prod', env: 'production' },

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -173,6 +173,7 @@ export interface PropertyFilterOperatorExtended<TokenValue> {
   match?: PropertyFilterOperatorMatch<TokenValue>;
   form?: PropertyFilterOperatorForm<TokenValue>;
   format?: PropertyFilterOperatorFormat<TokenValue>;
+  description?: string;
 }
 
 export type PropertyFilterTokenType = 'value' | 'enum';


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Adds an optional `description` field to the `PropertyFilterOperatorExtended` interface, allowing consumers to provide human-readable text for custom operators (e.g. "Matches regular expression" for `~`). This is used by the components package for operator dropdown labels and accessible token strings.

Also adds tests for custom operator filtering behavior: custom `match` functions, overriding predefined operator matching, and free text filtering across properties.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
